### PR TITLE
Assign_VLAN, No Ballooning, AppArmour Fix

### DIFF
--- a/ansible/helpers/ansible_hosts.txt.j2
+++ b/ansible/helpers/ansible_hosts.txt.j2
@@ -1,5 +1,6 @@
 [all:vars]
 cluster_name={{ cluster_name }}
+ansible_python_interpreter=auto_silent
 
 [kube_api_servers]
 {% for i in range(cluster_config.node_classes.apiserver.count) %}

--- a/ansible/prepare-nodes.yaml
+++ b/ansible/prepare-nodes.yaml
@@ -69,6 +69,28 @@
       tags:
         - kubelet_node_ip
 
+    # needed on recent Ubuntu versions. https://www.reddit.com/r/kubernetes/comments/1dv6z9d/ubuntu_2404_pod_termination_issue/
+    - name: Check if /etc/apparmor.d/runc profile exists
+      ansible.builtin.stat:
+        path: /etc/apparmor.d/runc
+      register: apparmor_runc_file_exists
+    - name: Check if /etc/apparmor.d/runc profile is disabled
+      ansible.builtin.stat:
+        path: /etc/apparmor.d/disable/runc
+      register: apparmor_runc_file_disabled
+    - name: Disable Default AppArmor Profile for Runc (containerd has its own)
+      ansible.builtin.command: sudo ln -s /etc/apparmor.d/runc /etc/apparmor.d/disable/
+      ignore_errors: yes
+      tags:
+        - disable_apparmor
+      when: apparmor_runc_file_exists.stat.exists and not apparmor_runc_file_disabled.stat.exists
+    - name: Reload AppArmor
+      ansible.builtin.command: sudo apparmor_parser -R /etc/apparmor.d/runc
+      ignore_errors: yes
+      tags:
+        - disable_apparmor
+      when: apparmor_runc_file_exists.stat.exists and not apparmor_runc_file_disabled.stat.exists
+
     - name: Set correct locale
       shell: |
         echo "LANG=en_US.UTF-8

--- a/clusters.tf
+++ b/clusters.tf
@@ -19,7 +19,8 @@ variable "clusters" {
     })
     networking                       : object({
       dns_search_domain              : string # search domain for DNS resolution
-      create_vlan                    : bool   # whether or not to create an IPv4 vlan.
+      assign_vlan                    : bool   # whether or not to assign a vlan to the network interfaces of the VMs.
+      create_vlan                    : bool   # whether or not to create an IPv4 vlan in Unifi.
       vlan_name                      : string # name of the IPv4 vlan for the cluster. Must always be set, even if create_vlan is false.
       vlan_id                        : number # vlan id for the cluster. Must always be set, even if create_vlan is false.
       ipv4                           : object({
@@ -150,7 +151,8 @@ variable "clusters" {
         dns_search_domain              = "lan"
         vlan_name                      = "ALPHA"
         vlan_id                        = 100
-        create_vlan                    = true
+        assign_vlan                    = false
+        create_vlan                    = false
         ipv4                           = {
           subnet_prefix                = "10.0.1"
           pod_cidr                     = "10.8.0.0/16"
@@ -266,6 +268,7 @@ variable "clusters" {
       }
       networking                       = {
         dns_search_domain              = "lan"
+        assign_vlan                    = true
         create_vlan                    = true
         vlan_name                      = "BETA"
         vlan_id                        = 200
@@ -384,6 +387,7 @@ variable "clusters" {
       }
       networking                       = {
         dns_search_domain              = "lan"
+        assign_vlan                    = true
         create_vlan                    = true
         vlan_name                      = "GAMMA"
         vlan_id                        = 600

--- a/k8s_vm_template/create_template_helper.sh
+++ b/k8s_vm_template/create_template_helper.sh
@@ -60,7 +60,7 @@ qm importdisk $TEMPLATE_VM_ID $PROXMOX_ISO_PATH/$IMAGE_NAME $PROXMOX_DATASTORE
 echo -e "${GREEN}Setting the VM options...${ENDCOLOR}"
 qm set $TEMPLATE_VM_ID \
   --scsihw virtio-scsi-pci \
-  --virtio0 "${PROXMOX_DATASTORE}:vm-${TEMPLATE_VM_ID}-disk-0,aio=native,iothread=1" \
+  --virtio0 "${PROXMOX_DATASTORE}:vm-${TEMPLATE_VM_ID}-disk-0,iothread=1" \
   --ide2 "${PROXMOX_DATASTORE}:cloudinit" \
   --boot c \
   --bootdisk virtio0 \

--- a/k8s_vm_template/create_template_helper.sh
+++ b/k8s_vm_template/create_template_helper.sh
@@ -16,7 +16,7 @@ set +a # stop automatically exporting
 set -e
 
 echo -e "${GREEN}Removing old image if it exists...${ENDCOLOR}"
-rm -f $PROXMOX_ISO_PATH/$IMAGE_NAME* 2&>1 >/dev/null
+rm -f $PROXMOX_ISO_PATH/$IMAGE_NAME* 2&>/dev/null
 
 echo -e "${GREEN}Downloading the image to get new updates...${ENDCOLOR}"
 wget -qO $PROXMOX_ISO_PATH/$IMAGE_NAME $IMAGE_LINK
@@ -50,6 +50,7 @@ qm create $TEMPLATE_VM_ID \
   --net0 virtio,bridge=vmbr0 \
   --agent "enabled=1,freeze-fs-on-backup=1,fstrim_cloned_disks=1" \
   --onboot 1 \
+  --balloon 0 \
   --autostart 1 \
   --cpu cputype=host \
   --numa 1

--- a/main.tf
+++ b/main.tf
@@ -163,9 +163,6 @@ resource "proxmox_virtual_environment_vm" "node" {
   }
   memory {
     dedicated = each.value.memory
-    floating  = (each.value.memory / 4) > 2048 ? each.value.memory / 4 : 2048
-    # guarantee only 1/4 of the memory, allowing you to overcommit memory and prevent OOMs.
-    # kubeadm stops you if there's less than 1700 MB of memory.
   }
   dynamic "disk" {
     for_each = each.value.disks

--- a/main.tf
+++ b/main.tf
@@ -176,10 +176,10 @@ resource "proxmox_virtual_environment_vm" "node" {
       file_format   = "raw"
       backup        = disk.value.backup # backup the disks during vm backup
       iothread      = true
-      cache         = "writeback" # proxmox default is 'none'. "writeback" is faster and safe on most hardware when protected against power loss. See https://pve.proxmox.com/wiki/Performance_Tweaks
-      aio           = "io_uring"  # proxmox default
-      discard       = "ignore"    # proxmox default
-      ssd           = false       # not possible with virtio
+      cache         = "none"     # proxmox default https://pve.proxmox.com/wiki/Performance_Tweaks
+      aio           = "io_uring" # proxmox default
+      discard       = "ignore"   # proxmox default
+      ssd           = false      # not possible with virtio
     }
   }
   agent {

--- a/main.tf
+++ b/main.tf
@@ -176,10 +176,10 @@ resource "proxmox_virtual_environment_vm" "node" {
       file_format   = "raw"
       backup        = disk.value.backup # backup the disks during vm backup
       iothread      = true
-      cache         = "none"   # proxmox default. "writeback" is faster, but it is not compatible with aio=native.
-      aio           = "native" # proxmox default is io_uring. use native with cache=none only. Native is only supported with raw block storage types like iSCSI, CEPH/RBD, and NVMe.
-      discard       = "ignore" # proxmox default
-      ssd           = false    # not possible with virtio
+      cache         = "writeback" # proxmox default is 'none'. "writeback" is faster and safe on most hardware when protected against power loss. See https://pve.proxmox.com/wiki/Performance_Tweaks
+      aio           = "io_uring"  # proxmox default
+      discard       = "ignore"    # proxmox default
+      ssd           = false       # not possible with virtio
     }
   }
   agent {

--- a/main.tf
+++ b/main.tf
@@ -42,9 +42,9 @@ locals {
           sockets            = specs.sockets
           memory             = specs.memory
           disks              = specs.disks
-          create_vlan      = cluster.networking.create_vlan
-          vlan_id          = cluster.networking.create_vlan ? cluster.networking.vlan_id: null
-          vlan_name        = cluster.networking.create_vlan ? cluster.networking.vlan_name: null
+          create_vlan        = cluster.networking.create_vlan
+          vlan_id            = cluster.networking.assign_vlan ? cluster.networking.vlan_id: null
+          vlan_name          = cluster.networking.create_vlan ? cluster.networking.vlan_name: null
           ipv4               : {
             vm_ip            = "${cluster.networking.ipv4.subnet_prefix}.${specs.start_ip + i}"
             gateway          = "${cluster.networking.ipv4.subnet_prefix}.1"
@@ -82,7 +82,8 @@ resource "local_file" "cluster_config_json" {
 resource "unifi_network" "vlan" {
   for_each = {
     for key, value in var.clusters : key => value
-    if key == terraform.workspace && value.networking.create_vlan == true
+    # only create a vlan if it's both wanted and the VMs are assigned to it
+    if key == terraform.workspace && value.networking.create_vlan == true && value.networking.assign_vlan == true
   }
 
   name      = each.value.networking.vlan_name


### PR DESCRIPTION
* Add `assign_vlan` variable for those without Unifi but use VLAN tags.
* Don't use ballooning or native disk cache (I use ZFS, it'd be double cached)
* Disable default runc AppArmour profile to fix permissions issues on Ubuntu 24.04 LTS