### PR TITLE
Use 'import-from' in 'qm set' so that disk import works for any type of datastore

### DIFF
--- a/k8s_vm_template/create_template_helper.sh
+++ b/k8s_vm_template/create_template_helper.sh
@@ -68,13 +68,10 @@ qm create "$TEMPLATE_VM_ID" \
   --cpu cputype=x86-64-v2-AES \
   --numa 1
 
-echo -e "${GREEN}Importing the disk...${ENDCOLOR}"
-qm importdisk "$TEMPLATE_VM_ID" "$PROXMOX_ISO_PATH"/"$IMAGE_NAME" "$PROXMOX_DATASTORE"
-
 echo -e "${GREEN}Setting the VM options...${ENDCOLOR}"
 qm set "$TEMPLATE_VM_ID" \
   --scsihw virtio-scsi-pci \
-  --virtio0 "${PROXMOX_DATASTORE}:vm-${TEMPLATE_VM_ID}-disk-0,iothread=1" \
+  --virtio0 "${PROXMOX_DATASTORE}:0,iothread=1,import-from=$PROXMOX_ISO_PATH/$IMAGE_NAME" \
   --ide2 "${PROXMOX_DATASTORE}:cloudinit" \
   --boot c \
   --bootdisk virtio0 \


### PR DESCRIPTION
https://forum.proxmox.com/threads/unable-to-parse-directory-volume-name-vm-777-disk-0.116996/#post-506240

Importing the disk differently