### PR TITLE
Update k8s.env to use Containerd version 1.7.12-0ubuntu4

### DIFF
--- a/k8s.env
+++ b/k8s.env
@@ -70,7 +70,7 @@ TEMPLATE_VM_NAME="k8s-ready-template"
 IMAGE_NAME="ubuntu-24.04-server-cloudimg-amd64.img"
 IMAGE_LINK="https://cloud-images.ubuntu.com/releases/24.04/release/${IMAGE_NAME}"
 EXTRA_TEMPLATE_TAGS="24.04-lts template"
-CONTAINERD_VERSION="1.7.12-0ubuntu4.1"
+CONTAINERD_VERSION="1.7.12-0ubuntu4"
 TEMPLATE_DISK_SIZE=5.6G # Add 1.8G more if installing nvidia drivers
 
 ### Debian 12 Image (Bookworm)


### PR DESCRIPTION
The previous version of containerd package `1.7.12-0ubuntu4.1` does not exist, so replacing with `1.7.12-0ubuntu4`.