### PR TITLE
Make gateway configurable instead of fixing it

### DIFF
--- a/terraform/clusters.tf
+++ b/terraform/clusters.tf
@@ -26,7 +26,7 @@ variable "clusters" {
         svc_cidr             : optional(string, "10.43.0.0/16")                           # Optional. Cidr range for service networking internal to cluster. Shouldn't overlap with ipv4 lan network.
         dns1                 : optional(string, "1.1.1.1")                                # Optional. Primary dns server for vm hosts
         dns2                 : optional(string, "1.0.0.1")                                # Optional. Secondary dns server for vm hosts
-        gateway              : optional(string, "1.0.0.1")                                # Optional. Gateway for vm hosts
+        gateway              : string                                                     # Required. Gateway for vm hosts
         management_cidrs     : optional(string, "")                                       # Optional. Proxmox list of ipv4 IPs or cidrs that you want to be able to reach the K8s api and ssh into the hosts. Only used if use_pve_firewall is true.
         lb_cidrs             : optional(string, "")                                       # Optional. IPv4 cidrs to use for MetalLB.
       })
@@ -89,6 +89,7 @@ variable "clusters" {
           subnet_prefix        = "10.0.1"
           management_cidrs     = "10.0.0.0/30,10.0.60.2,10.0.50.5,10.0.50.6"
           lb_cidrs             = "10.0.1.200/29,10.0.1.208/28,10.0.1.224/28,10.0.1.240/29,10.0.1.248/30,10.0.1.252/31"
+          gateway              = "10.0.1.1"
         }
         ipv6 = {}
         kube_vip = {
@@ -124,6 +125,7 @@ variable "clusters" {
           subnet_prefix        = "10.0.2"
           management_cidrs     = "10.0.0.0/30,10.0.60.2,10.0.50.5,10.0.50.6"
           lb_cidrs             = "10.0.2.200/29,10.0.2.208/28,10.0.2.224/28,10.0.2.240/29,10.0.2.248/30,10.0.2.252/31"
+          gateway              = "10.0.2.1"
         }
         ipv6 = {}
         kube_vip = {
@@ -171,6 +173,7 @@ variable "clusters" {
           subnet_prefix        = "10.0.3"
           management_cidrs     = "10.0.0.0/30,10.0.60.2,10.0.50.5,10.0.50.6"
           lb_cidrs             = "10.0.3.200/29,10.0.3.208/28,10.0.3.224/28,10.0.3.240/29,10.0.3.248/30,10.0.3.252/31"
+          gateway              = "10.0.3.1"
         }
         ipv6 = {}
         kube_vip = {

--- a/terraform/clusters.tf
+++ b/terraform/clusters.tf
@@ -26,6 +26,7 @@ variable "clusters" {
         svc_cidr             : optional(string, "10.43.0.0/16")                           # Optional. Cidr range for service networking internal to cluster. Shouldn't overlap with ipv4 lan network.
         dns1                 : optional(string, "1.1.1.1")                                # Optional. Primary dns server for vm hosts
         dns2                 : optional(string, "1.0.0.1")                                # Optional. Secondary dns server for vm hosts
+        gateway              : optional(string, "1.0.0.1")                                # Optional. Gateway for vm hosts
         management_cidrs     : optional(string, "")                                       # Optional. Proxmox list of ipv4 IPs or cidrs that you want to be able to reach the K8s api and ssh into the hosts. Only used if use_pve_firewall is true.
         lb_cidrs             : optional(string, "")                                       # Optional. IPv4 cidrs to use for MetalLB.
       })

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -23,7 +23,7 @@ locals {
           vlan_id            = cluster.networking.vlan_id == null ? "${cluster.cluster_id}00" : cluster.networking.vlan_id
           ipv4               : {
             vm_ip            = "${cluster.networking.ipv4.subnet_prefix}.${specs.start_ip + i}"
-            gateway          = "${cluster.networking.ipv4.subnet_prefix}.1"
+            gateway          = "${cluster.networking.ipv4.gateway}"
             dns1             = cluster.networking.ipv4.dns1
             dns2             = cluster.networking.ipv4.dns2
             lb_cidrs         = cluster.networking.ipv4.lb_cidrs 

--- a/terraform/nodes.tf
+++ b/terraform/nodes.tf
@@ -105,7 +105,7 @@ resource "proxmox_virtual_environment_vm" "node" {
     dns {
       domain = each.value.dns_search_domain
       servers = concat(
-        [each.value.ipv4.dns1, each.value.ipv4.dns2, each.value.ipv4.gateway],
+        [each.value.ipv4.dns1, each.value.ipv4.dns2],
           each.value.ipv6.enabled ? [each.value.ipv6.dns1, each.value.ipv6.dns2] : []
       )
     }


### PR DESCRIPTION
Hello !

My setup is using gateway IP terminating with .254
So I made a very little change to permit configuration of VM gateway in terraform/clusters.tf
I've made the corresponding change to terrform/local.tf  

Tested it, works fine so I could succesfully bootstrap my cluster !

As a bonus I retired the gateway IP from DNS to avoid DNS trafic to my gateway in terraform/nodes.tf but this change is less crucial. 
