### PR TITLE
Add assign_vlan check. If true, assign something. If not, set null.

### DIFF
--- a/terraform/clusters.tf
+++ b/terraform/clusters.tf
@@ -236,4 +236,3 @@ variable "clusters" {
     }
   }
 }
-

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -20,7 +20,7 @@ locals {
           cpu_type           = specs.cpu_type
           bridge             = cluster.networking.bridge
           use_unifi          = cluster.networking.use_unifi
-          vlan_id            = cluster.networking.vlan_id == null ? "${cluster.cluster_id}00" : cluster.networking.vlan_id
+          vlan_id            = cluster.networking.assign_vlan ? (cluster.networking.vlan_id == null ? "${cluster.cluster_id}00" : cluster.networking.vlan_id) : null
           ipv4               : {
             vm_ip            = "${cluster.networking.ipv4.subnet_prefix}.${specs.start_ip + i}"
             gateway          = cluster.networking.ipv4.gateway


### PR DESCRIPTION
* Sets vlan to null (0) if `assign_vlan` is false
* Sets vlan to `${cluster_id}00` if `assign_vlan` is true, but no vlan id is provided (i.e. 500 for a cluster_id of 5)
* Sets vlan to vlan_id if it is provided and assign_vlan is true