### PR TITLE
Switch shebangs to use /usr/bin/env

### DIFF
--- a/clustercreator.sh
+++ b/clustercreator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Variables
 export GREEN='\033[32m'

--- a/scripts/add_nodes.sh
+++ b/scripts/add_nodes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr add-nodes"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr bootstrap"

--- a/scripts/configure_clusters.sh
+++ b/scripts/configure_clusters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr configure-clusters"

--- a/scripts/configure_secrets.sh
+++ b/scripts/configure_secrets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr configure-secrets"

--- a/scripts/configure_variables.sh
+++ b/scripts/configure_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr configure-variables"

--- a/scripts/delete_node.sh
+++ b/scripts/delete_node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr delete-node <hostname>"

--- a/scripts/drain_node.sh
+++ b/scripts/drain_node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr drain-node <hostname> [-t/--timeout <seconds>]"

--- a/scripts/k8s_vm_template/FilesToPlace/apt-packages.sh
+++ b/scripts/k8s_vm_template/FilesToPlace/apt-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -a # automatically export all variables
 source /etc/k8s.env

--- a/scripts/k8s_vm_template/FilesToPlace/extra-kernel-modules.sh
+++ b/scripts/k8s_vm_template/FilesToPlace/extra-kernel-modules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Define the package for the current kernel
 current_kernel_version=$(uname -r)

--- a/scripts/k8s_vm_template/FilesToPlace/source-packages.sh
+++ b/scripts/k8s_vm_template/FilesToPlace/source-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Install packages from source
 # MIRRORS ansible/reinstall-source-packages.yaml

--- a/scripts/k8s_vm_template/FilesToPlace/watch-disk-space.sh
+++ b/scripts/k8s_vm_template/FilesToPlace/watch-disk-space.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if the script is running under watch; if not, rerun it with watch -n 1
 if [[ "$1" != "--watched" ]]; then

--- a/scripts/k8s_vm_template/FilesToRun/install_packages.sh
+++ b/scripts/k8s_vm_template/FilesToRun/install_packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -a # automatically export all variables
 source /etc/k8s.env

--- a/scripts/k8s_vm_template/create_template_helper.sh
+++ b/scripts/k8s_vm_template/create_template_helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Record the start time
 start_time_total=$(date +%s)

--- a/scripts/reset_all_nodes.sh
+++ b/scripts/reset_all_nodes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr reset-all-nodes"

--- a/scripts/reset_node.sh
+++ b/scripts/reset_node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr reset-node <hostname_or_node_class>"

--- a/scripts/run_command.sh
+++ b/scripts/run_command.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
     echo "Usage: ccr command 'command_to_run' [<hostname_or_node_class>]"

--- a/scripts/template.sh
+++ b/scripts/template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr template"

--- a/scripts/toggle_providers.sh
+++ b/scripts/toggle_providers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr toggle-providers"

--- a/scripts/upgrade_addons.sh
+++ b/scripts/upgrade_addons.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr upgrade-addons"

--- a/scripts/upgrade_k8s.sh
+++ b/scripts/upgrade_k8s.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr upgrade-k8s"

--- a/scripts/upgrade_node.sh
+++ b/scripts/upgrade_node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Usage: ccr upgrade-node <hostname_or_node_class>"

--- a/scripts/vmctl.sh
+++ b/scripts/vmctl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
     echo "Usage: ccr vmctl [start|shutdown|pause|resume|hibernate|stop|snapshot|backup] [--timeout <seconds>]"


### PR DESCRIPTION
Hi @christensenjairus - great project! 👏🏻 

I've had to make a few tweaks getting it to work in my environment, so I've got a few small changes to propose. I'm using a NixOS VM as my Ansible host which I think is the source of some of the differences I'm seeing. Here's the first one:

----

Hardcoded /bin/bash does not work in NixOS environments, and /usr/bin/env should work in most places.