### PR TITLE
Allow custom containerd & repository configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ terraform/terraform.tfstate*
 ansible/tmp
 *.DS_Store
 scripts/.env
+.claude

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ This will open the files for you to set
   - `PROXMOX_USERNAME` can be `root` or a user that can run `sudo` commands ***without a password***.
 - **Unifi Information**: (optional, needs to be toggled on first) The Unifi API url.
 - **Minio Bucket, Region, and URL**: (optional, needs to be toggled on first) The minio bucket, region, and URL for storing Tofu state.
+- **Custom containerd configuration**: Override containerd configuration with [imports](https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#:~:text=as%20a%20duration-,imports,-%3A%20Imports%20is%20a).
 
 ### 6. Configure Secrets
 
@@ -307,6 +308,7 @@ Manage your K8s VMs using the other commands:
 * `ccr upgrade-k8s`
 * `ccr vmctl`
 * `ccr run-command`
+* `ccr update-containerd` - Pushes containerd configuration (`config.d/` and `certs.d/`) to cluster nodes. Nodes are updated one at a time.
   Each can be run with `--help` for more information on how they work, their arguments, and their flags.
 
 ---

--- a/ansible/update-containerd.yaml
+++ b/ansible/update-containerd.yaml
@@ -1,0 +1,48 @@
+---
+- name: Update containerd configuration
+  hosts: all
+  serial: 1
+  gather_facts: false
+  become: true
+  tasks:
+
+    - name: Ensure containerd config.d directory exists
+      ansible.builtin.file:
+        path: /etc/containerd/config.d
+        state: directory
+        mode: '0755'
+
+    - name: Ensure containerd certs.d directory exists
+      ansible.builtin.file:
+        path: /etc/containerd/certs.d
+        state: directory
+        mode: '0755'
+
+    - name: Enable containerd config.d imports
+      ansible.builtin.replace:
+        path: /etc/containerd/config.toml
+        regexp: '^imports = \[\]'
+        replace: 'imports = ["/etc/containerd/config.d/*.toml"]'
+      notify: Restart containerd
+
+    - name: Synchronize containerd config.d files
+      ansible.builtin.copy:
+        src: ../scripts/k8s_vm_template/FilesToPlace/containerd.config.d/
+        dest: /etc/containerd/config.d/
+        mode: '0644'
+        directory_mode: '0755'
+      notify: Restart containerd
+
+    - name: Synchronize containerd certs.d files
+      ansible.builtin.copy:
+        src: ../scripts/k8s_vm_template/FilesToPlace/containerd.certs.d/
+        dest: /etc/containerd/certs.d/
+        mode: '0600'
+        directory_mode: '0755'
+      notify: Restart containerd
+
+  handlers:
+    - name: Restart containerd
+      ansible.builtin.systemd:
+        name: containerd
+        state: restarted

--- a/clustercreator.sh
+++ b/clustercreator.sh
@@ -201,26 +201,27 @@ display_usage() {
     echo "Usage: clustercreator.sh|ccr <command> [options]"
     echo ""
     echo "Commands:"
-    echo "  setup-ccr            Creates 'ccr' command and tells it where to look for scripts"
-    echo "  ctx                  Sets the current cluster context"
-    echo "  configure-variables  Opens files with variables to be used by bash, ansible, and tofu"
-    echo "  configure-secrets    Guides you though setting secrets to be used by bash, ansible, and tofu"
-    echo "  configure-clusters   Opens your clusters configuration file"
-    echo "  configure-networks   Opens your networks configuration file"
-    echo "  template             Creates a VM template for Kubernetes"
-    echo "  tofu                 Executes tofu commands directly"
-    echo "  bootstrap            Bootstraps Kubernetes to create a cluster"
-    echo "  add-nodes            Adds un-joined nodes to the cluster"
-    echo "  drain-node           Drains a node of workloads"
-    echo "  delete-node          Immediately deletes the node from the Kubernetes cluster"
-    echo "  upgrade-node         Upgrades a node to use the Kubernetes version specified in the environment settings"
-    echo "  reset-node           Resets Kubernetes configurations for one host"
-    echo "  reset-all-nodes      Resets Kubernetes configurations for all hosts"
-    echo "  upgrade-addons       Upgrades the addons to the versions specified in the environment settings"
-    echo "  upgrade-k8s          Upgrades the control-plane api to the version specified in the environment settings"
-    echo "  vmctl                Controls VM state, including power controls and backups"
-    echo "  run-command          Runs a bash command on a host or an Ansible host group"
-    echo "  toggle-providers     Toggles the S3 (Minio) and Unifi providers"
+    echo "  setup-ccr           Creates 'ccr' command and tells it where to look for scripts"
+    echo "  ctx                 Sets the current cluster context"
+    echo "  configure-variables Opens files with variables to be used by bash, ansible, and tofu"
+    echo "  configure-secrets   Guides you though setting secrets to be used by bash, ansible, and tofu"
+    echo "  configure-clusters  Opens your clusters configuration file"
+    echo "  configure-networks  Opens your networks configuration file"
+    echo "  template            Creates a VM template for Kubernetes"
+    echo "  tofu                Executes tofu commands directly"
+    echo "  bootstrap           Bootstraps Kubernetes to create a cluster"
+    echo "  add-nodes           Adds un-joined nodes to the cluster"
+    echo "  drain-node          Drains a node of workloads"
+    echo "  delete-node         Immediately deletes the node from the Kubernetes cluster"
+    echo "  upgrade-node        Upgrades a node to use the Kubernetes version specified in the environment settings"
+    echo "  reset-node          Resets Kubernetes configurations for one host"
+    echo "  reset-all-nodes     Resets Kubernetes configurations for all hosts"
+    echo "  upgrade-addons      Upgrades the addons to the versions specified in the environment settings"
+    echo "  upgrade-k8s         Upgrades the control-plane api to the version specified in the environment settings"
+    echo "  vmctl               Controls VM state, including power controls and backups"
+    echo "  run-command         Runs a bash command on a host or an Ansible host group"
+    echo "  update-containerd   Pushes containerd config.d and certs.d to cluster nodes"
+    echo "  toggle-providers    Toggles the S3 (Minio) and Unifi providers"
     echo ""
     echo "Use the -h/--help flag following a command for more descriptive help output."
 }
@@ -320,7 +321,8 @@ if [[ "$COMMAND" == "template" || \
       "$COMMAND" == "upgrade-addons" || \
       "$COMMAND" == "upgrade-k8s" || \
       "$COMMAND" == "vmctl" || \
-      "$COMMAND" == "run-command" \
+      "$COMMAND" == "run-command" || \
+      "$COMMAND" == "update-containerd" \
     ]]; then
     check_required_vars "${required_vars[@]}"
     print_env_vars "${required_vars[@]}"
@@ -381,6 +383,9 @@ case "$COMMAND" in
         ;;
     run-command)
         ( "$REPO_PATH/scripts/run_command.sh" "$@" )
+        ;;
+    update-containerd)
+        ( "$REPO_PATH/scripts/update_containerd.sh" "$@" )
         ;;
     toggle-providers)
         ( "$REPO_PATH/scripts/toggle_providers.sh" "$@" )

--- a/scripts/configure_variables.sh
+++ b/scripts/configure_variables.sh
@@ -50,4 +50,10 @@ if [[ "$answer" =~ ^[Yy]$ ]]; then
   fi
 fi
 
+CONTAINERD_CONFIG_DIR="$REPO_PATH/scripts/k8s_vm_template/FilesToPlace/containerd.config.d"
+read -p "Create custom containerd config? (y/n): " answer
+if [[ "$answer" =~ ^[Yy]$ ]]; then
+  vim "$CONTAINERD_CONFIG_DIR/custom.toml"
+fi
+
 echo -e "${GREEN}DONE${ENDCOLOR}"

--- a/scripts/k8s_vm_template/FilesToPlace/apt-packages.sh
+++ b/scripts/k8s_vm_template/FilesToPlace/apt-packages.sh
@@ -190,8 +190,11 @@ else
 fi
 
 # Create default containerd config
-mkdir -p /etc/containerd
+mkdir -p /etc/containerd/{config.d,certs.d}
 containerd config default | tee /etc/containerd/config.toml
+
+# Allow user-configured containerd config
+sed -i 's|imports = \[\]|imports = ["/etc/containerd/config.d/*.toml"]|' /etc/containerd/config.toml
 
 # Setup cgroup drivers (will use systemd, not cgroupfs, because its native to Debian/Ubuntu)
 sed -i '/SystemdCgroup = false/s/false/true/' /etc/containerd/config.toml

--- a/scripts/k8s_vm_template/FilesToPlace/containerd.certs.d/.gitignore
+++ b/scripts/k8s_vm_template/FilesToPlace/containerd.certs.d/.gitignore
@@ -1,0 +1,2 @@
+/*.toml
+*/hosts.toml

--- a/scripts/k8s_vm_template/FilesToPlace/containerd.certs.d/README.md
+++ b/scripts/k8s_vm_template/FilesToPlace/containerd.certs.d/README.md
@@ -1,0 +1,21 @@
+# Containerd Registry Configuration
+
+As of containerd v1.5, registry configuration is handled with `config_path`. See [documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---introduction).
+
+For each registry, create a `<registry-name>/hosts.toml` file. For example if you have a mirror for Docker Hub, create `docker.io/hosts.toml` with:
+
+```toml
+server = "https://registry-1.docker.io"
+
+[host."https://my-mirror.example.com"]
+  capabilities = ["pull", "resolve"]
+  [host."https://my-mirror.example.com".header]
+    authorization = ["Basic <BASE64_ENCODED_CREDENTIALS>"]
+
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
+```
+Generate `<BASE64_ENCODED_CREDENTIALS>` with:
+```sh
+$ echo -n "user:password" | base64 -w 0
+```

--- a/scripts/k8s_vm_template/FilesToPlace/containerd.config.d/README.md
+++ b/scripts/k8s_vm_template/FilesToPlace/containerd.config.d/README.md
@@ -1,0 +1,5 @@
+# Custom containerd config
+
+TOML files (`*.toml`) in this directory will be installed to `/etc/containerd/config.d` for all K8s nodes.
+
+For custom registries and mirrors, see [certs.d documentation](../containerd.certs.d/README.md).

--- a/scripts/k8s_vm_template/FilesToPlace/containerd.config.d/custom.toml
+++ b/scripts/k8s_vm_template/FilesToPlace/containerd.config.d/custom.toml
@@ -1,0 +1,2 @@
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/certs.d"

--- a/scripts/k8s_vm_template/create_template_helper.sh
+++ b/scripts/k8s_vm_template/create_template_helper.sh
@@ -33,6 +33,8 @@ echo ""
 echo -e "${GREEN}Update, add packages, enable services, edit multipath config, set timezone, set firstboot scripts...${ENDCOLOR}"
 sudo virt-customize -a "$PROXMOX_ISO_PATH"/"$IMAGE_NAME" \
      --mkdir /etc/systemd/system/containerd.service.d/ \
+     --mkdir /etc/containerd/config.d/ \
+     --mkdir /etc/containerd/certs.d/ \
      --copy-in ./FilesToPlace/override.conf:/etc/systemd/system/containerd.service.d/ \
      --copy-in ./FilesToPlace/multipath.conf:/etc/ \
      --copy-in ./FilesToPlace/k8s_mods.conf:/etc/modules-load.d/ \
@@ -46,6 +48,8 @@ sudo virt-customize -a "$PROXMOX_ISO_PATH"/"$IMAGE_NAME" \
      --copy-in ./FilesToPlace/watch-disk-space.sh:/root/ \
      --copy-in ./FilesToPlace/extra-kernel-modules.sh:/root/ \
      --copy-in ./FilesToPlace/encryption-manifest-edit.sh:/usr/local/bin/ \
+     --copy-in ./FilesToPlace/containerd.config.d/:/etc/containerd/config.d/ \
+     --copy-in ./FilesToPlace/containerd.certs.d/:/etc/containerd/certs.d/ \
      --copy-in k8s.env:/etc/ \
      --install qemu-guest-agent,cloud-init \
      --timezone "$TIMEZONE" \

--- a/scripts/update_containerd.sh
+++ b/scripts/update_containerd.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "Usage: ccr update-containerd [hostname_or_node_class]"
+  echo ""
+  echo "Pushes containerd configuration (config.d/ and certs.d/) to cluster nodes and restarts containerd."
+  echo "Nodes are updated one at a time to avoid cluster disruption."
+  echo ""
+  echo "Options:"
+  echo "  -h, --help    Show this help message"
+  echo ""
+  echo "Arguments:"
+  echo "  hostname_or_node_class  (optional) Limit to a specific node or node class"
+}
+
+TARGETED_NODE=""
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage; exit 0 ;;
+        *)
+          if [[ -z "$TARGETED_NODE" ]]; then
+              TARGETED_NODE="$1"
+          else
+              echo "Unknown parameter passed: $1"
+              usage
+              exit 1
+          fi
+          ;;
+    esac
+    shift
+done
+
+echo -e "${GREEN}Updating containerd configuration for cluster: $CLUSTER_NAME${ENDCOLOR}"
+
+# --------------------------- Script Start ---------------------------
+
+# Generate inventory (runs on localhost, no limit)
+run_playbooks "generate-hosts-txt.yaml"
+
+if [[ -n "$TARGETED_NODE" ]]; then
+  run_playbooks "--limit=${TARGETED_NODE}" "update-containerd.yaml"
+else
+  run_playbooks "update-containerd.yaml"
+fi
+
+# ---------------------------- Script End ----------------------------
+
+echo -e "${GREEN}DONE${ENDCOLOR}"


### PR DESCRIPTION
This is useful for e.g. adding registry mirrors using Harbor, without
having to modify the default config.

It's also cleaner, with `ccr configure-variables` support.

It also includes a new `ccr update-containerd` command so existing nodes
can be updated without replacing them.