### PR TITLE
Update Helm APT repository

### DIFF
--- a/scripts/k8s_vm_template/FilesToPlace/apt-packages.sh
+++ b/scripts/k8s_vm_template/FilesToPlace/apt-packages.sh
@@ -34,8 +34,8 @@ curl -fsSL "https://pkgs.k8s.io/core:/stable:/v${KUBERNETES_SHORT_VERSION}/deb/R
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${KUBERNETES_SHORT_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
 
 # add helm apt repository
-curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
 
 # update apt cache
 apt-get update


### PR DESCRIPTION
The old one is dead and breaks `ccr add-nodes`. This is the current [official repo](https://helm.sh/docs/intro/install/#from-apt-debianubuntu).