### PR TITLE
Ansible Updates to Prevent Deprecation Warnings and Other Fixes

### DIFF
--- a/ansible/cilium-setup.yaml
+++ b/ansible/cilium-setup.yaml
@@ -4,15 +4,15 @@
   tags:
     - cilium_basic_install
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Calculate the count of non-API/ETCD servers
       set_fact:
-        non_api_etcd_server_count: "{{ groups['all'] | length - (groups['controlplane'] | default([]) | length + groups['etcd'] | default([]) | length) }}"
+        non_api_etcd_server_count: "{{ (groups['all'] | length) - ((groups['controlplane'] | default([]) | length) + (groups['etcd'] | default([]) | length)) }}"
 
     - name: Determine non-API/ETCD server count
       set_fact:
-        replica_count: "{{ 1 if non_api_etcd_server_count <= \"1\" else 2 }}"
+        replica_count: "{{ 1 if (non_api_etcd_server_count | int) <= 1 else 2 }}"
 
     - name: Generate cilium.yaml configuration file
       become: yes

--- a/ansible/conditionally-taint-controlplane.yaml
+++ b/ansible/conditionally-taint-controlplane.yaml
@@ -2,7 +2,7 @@
   hosts: controlplane
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - conditionally_taint_control_plane_nodes
   tasks:

--- a/ansible/controlplane-setup.yaml
+++ b/ansible/controlplane-setup.yaml
@@ -19,7 +19,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Deploy kubeadm config file
       ansible.builtin.template:
@@ -34,9 +34,9 @@
       register: kube_config_exists
       become: true
 
-    - name: Fail if kubeadm init has already been run
-      fail:
-        msg: "Cluster has already been bootstrapped"
+    - name: Note if kubeadm init has already been run
+      ansible.builtin.debug:
+        msg: "Cluster has already been bootstrapped; skipping kubeadm init tasks"
       when: kube_config_exists.stat.exists
 
     # update and upgrade controlplane-0 node and reboot if necessary - but only if kubeadm init has not been run
@@ -175,9 +175,15 @@
   become: true
   gather_facts: false
   tasks:
+    - name: Check if kubeadm init has already been run
+      ansible.builtin.stat:
+        path: /etc/kubernetes/admin.conf
+      register: kube_config_exists
+
     - name: Create a bootstrap marker file
       ansible.builtin.file:
         path: /root/.bootstrap
         state: touch
+      when: kube_config_exists.stat.exists
       tags:
         - kubeadm_init

--- a/ansible/delete-node.yaml
+++ b/ansible/delete-node.yaml
@@ -3,7 +3,7 @@
   hosts: controlplane
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
 
   tasks:
     - name: Fetch active controlplane nodes

--- a/ansible/ending-output.yaml
+++ b/ansible/ending-output.yaml
@@ -29,7 +29,7 @@
   hosts: controlplane[0]
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
     kubeconfig: "{{ lookup('env', 'HOME') }}/.kube/{{ cluster_config.kubeconfig_file_name }}"
   tasks:
     - name: Read etcd encryption secret

--- a/ansible/etcd-encryption.yaml
+++ b/ansible/etcd-encryption.yaml
@@ -6,7 +6,7 @@
   vars:
     enc_key_path: /etc/kubernetes/enc/enc.key
     enc_file_path: /etc/kubernetes/enc/enc.yaml
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Check if the encryption key file exists on each node
       ansible.builtin.stat:
@@ -27,7 +27,7 @@
         src: "{{ enc_key_path }}"
       register: slurped_key
       when: key_source_node is defined
-      delegate_to: "{{ key_source_node }}"
+      delegate_to: "{{ key_source_node | default(inventory_hostname) }}"
       run_once: true
 
     - name: Set encryption key fact from existing key
@@ -62,10 +62,11 @@
         owner: root
         group: root
 
-    - name: "Display encryption key"
-      debug:
-        msg: "Encryption key: {{ encryption_key }}"
+    - name: Confirm encryption key is set
+      ansible.builtin.debug:
+        msg: "Encryption key has been set"
       run_once: true
+      no_log: true
 
     - name: Ensure the directory for the encryption config exists
       ansible.builtin.file:

--- a/ansible/etcd-nodes-setup.yaml
+++ b/ansible/etcd-nodes-setup.yaml
@@ -183,7 +183,7 @@
   tags:
     - ssh_key_copy
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
     root_ssh_key_local_path: "{{ ssh_key_file }}"
   tasks:
     - name: Ensure .ssh directory exists for root
@@ -206,7 +206,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Remove the PKI directory if it exists
       ansible.builtin.file:
@@ -241,7 +241,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Adjust permissions on PKI files for synchronization on etcd-0
       ansible.builtin.file:
@@ -265,7 +265,7 @@
   any_errors_fatal: true
   become: true # Execute tasks with elevated privileges
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Set correct permissions for PKI files and directories
       ansible.builtin.shell: |
@@ -301,7 +301,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Initialize etcd with specific configuration
       ansible.builtin.command: sudo kubeadm init phase etcd local --config=/home/{{ cluster_config.ssh.ssh_user }}/kubeadmcfg.yaml
@@ -314,7 +314,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Copy ca.crt to controlplane-0
       ansible.builtin.shell:
@@ -342,7 +342,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Ensure PKI directories exist
       ansible.builtin.file:
@@ -398,7 +398,7 @@
   become: true
   vars:
     etcd_yaml_path: "/etc/kubernetes/manifests/etcd.yaml"
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Backup the etcd YAML file to ~/.etcd.bak
       ansible.builtin.command: "cp {{ etcd_yaml_path }} /home/{{ cluster_config.ssh.ssh_user }}/.etcd.bak"
@@ -462,7 +462,7 @@
   gather_facts: false
   become: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - etcd_performance_tuning
   tasks:
@@ -503,7 +503,7 @@
   gather_facts: false
   become: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - etcd_health_alias
   tasks:
@@ -522,7 +522,7 @@
   gather_facts: false
   become: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - etcd_health_alias
   tasks:

--- a/ansible/generate-hosts-txt.yaml
+++ b/ansible/generate-hosts-txt.yaml
@@ -3,7 +3,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
     cluster_name: "{{ cluster_config.cluster_name }}"
     node_classes: "{{ cluster_config.node_classes }}"
     networking: "{{ cluster_config.networking }}"

--- a/ansible/get-join-commands.yaml
+++ b/ansible/get-join-commands.yaml
@@ -3,7 +3,7 @@
   hosts: controlplane
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
     control_plane_host: null
 
   tasks:

--- a/ansible/join-controlplane-nodes.yaml
+++ b/ansible/join-controlplane-nodes.yaml
@@ -4,7 +4,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
     control_plane_host: null
   tasks:
     # finding an controlplane node is necessary because we can't use controlplane[0] because it could be a new node.

--- a/ansible/join-worker-nodes.yaml
+++ b/ansible/join-worker-nodes.yaml
@@ -4,7 +4,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
     control_plane_host: null
   tasks:
     # finding an controlplane node is necessary because we can't use controlplane[0] because it could be a new node.
@@ -122,7 +122,7 @@
 
     - name: Read worker join command
       set_fact:
-        join_command_local: "{{ lookup('file', 'tmp/{{ cluster_name }}/worker_join_command.sh') }}"
+        join_command_local: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/worker_join_command.sh') }}"
       when:
         - "'controlplane' not in group_names and 'etcd' not in group_names"
         - not is_in_cluster

--- a/ansible/kubelet-csr-approver.yaml
+++ b/ansible/kubelet-csr-approver.yaml
@@ -3,7 +3,7 @@
   hosts: controlplane[0]
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
 
     - name: Calculate the count of non-API/ETCD servers
@@ -12,11 +12,11 @@
 
     - name: Determine if needing HA based on non-API/ETCD server count
       set_fact:
-        kubelet_csr_approver_replica_count: "{{ 1 if non_api_etcd_server_count <= \"1\" else 2 }}"
+        kubelet_csr_approver_replica_count: "{{ 1 if (non_api_etcd_server_count | int) <= 1 else 2 }}"
 
     - name: Download the kubelet-serving-cert-approver manifest
       ansible.builtin.get_url:
-        url: "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/refs/tags/v{{ kubelet_serving_cert_approver_version }}/deploy/{{ 'standalone' if kubelet_csr_approver_replica_count == '1' else 'ha' }}-install.yaml"
+        url: "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml"
         dest: "/tmp/kubelet-approver-install.yaml"
         validate_certs: no # sometimes older ansible packages have a problem with ssl
 

--- a/ansible/kubevip-setup.yaml
+++ b/ansible/kubevip-setup.yaml
@@ -3,7 +3,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - vip_manifest
   tasks:

--- a/ansible/label-and-taint-nodes.yaml
+++ b/ansible/label-and-taint-nodes.yaml
@@ -5,7 +5,7 @@
 
   vars:
     ansible_hosts_path: "tmp/{{ cluster_name }}/ansible-hosts.txt"
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
     etcd_group_exists: "{{ 'etcd' in groups }}"  # Check if the etcd group exists
 
   tasks:

--- a/ansible/local-storageclasses-setup.yaml
+++ b/ansible/local-storageclasses-setup.yaml
@@ -2,7 +2,7 @@
   hosts: controlplane[0]
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
     default_storage_class_name: "local-path"
   tasks:
     - name: Generate Non-Auto-Provisioning Local StorageClass Yaml

--- a/ansible/metallb-setup.yaml
+++ b/ansible/metallb-setup.yaml
@@ -4,7 +4,7 @@
   tags:
     - metallb_basic_install
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
 
     - name: Generate MetalLB configuration files

--- a/ansible/metrics-server-setup.yaml
+++ b/ansible/metrics-server-setup.yaml
@@ -3,7 +3,7 @@
   hosts: controlplane[0]
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
 
     - name: Calculate the count of non-API/ETCD servers
@@ -12,7 +12,7 @@
 
     - name: Determine if needing HA based on non-API/ETCD server count
       set_fact:
-        metrics_server_replica_count: "{{ 1 if non_api_etcd_server_count <= \"1\" else 2 }}"
+        metrics_server_replica_count: "{{ 1 if (non_api_etcd_server_count | int) <= 1 else 2 }}"
 
     - name: Add Metrics-Server Helm repository
       ansible.builtin.shell:

--- a/ansible/move-kubeconfig-local.yaml
+++ b/ansible/move-kubeconfig-local.yaml
@@ -2,7 +2,7 @@
   hosts: controlplane[0]
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - move_kubeconfig_remote
   tasks:
@@ -39,7 +39,7 @@
   hosts: controlplane[0]
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - move_kubeconfig_local
   tasks:
@@ -56,7 +56,7 @@
   connection: local
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - rename_kubeconfig_context
   tasks:
@@ -74,8 +74,8 @@
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/.kube/{{ cluster_config.kubeconfig_file_name }}"
       when:
-        - "'kubernetes-admin@' + cluster_config.cluster_name in kubectl_contexts.stdout"
-        - cluster_config.cluster_name + ' not in kubectl_contexts.stdout'
+        - ("kubernetes-admin@" ~ cluster_config.cluster_name) in kubectl_contexts.stdout
+        - cluster_config.cluster_name not in kubectl_contexts.stdout
     - name: Replace kubernetes-admin username in kubeconfig
       ansible.builtin.replace:
         path: "{{ lookup('env', 'HOME') }}/.kube/{{ cluster_config.kubeconfig_file_name }}"
@@ -92,7 +92,7 @@
         replace: "{{ new_vip }}"
     - name: Set the current context to the new cluster name
       ansible.builtin.command:
-        cmd: kubectl config use-context {{ cluster_config.cluster_name }}
+        cmd: kubectl config use-context {{ cluster_config.cluster_name }}-admin@{{ cluster_config.cluster_name }}
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/.kube/{{ cluster_config.kubeconfig_file_name }}"
     - name: "'kubectl get nodes' from machine running ansible to verify kubeconfig has been set up correctly"

--- a/ansible/move-kubeconfig-remote.yaml
+++ b/ansible/move-kubeconfig-remote.yaml
@@ -2,7 +2,7 @@
   hosts: all
   gather_facts: false
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tags:
     - move_kubeconfig_remote
   tasks:

--- a/ansible/prepare-nodes.yaml
+++ b/ansible/prepare-nodes.yaml
@@ -29,7 +29,7 @@
   gather_facts: true # needs to know OS type
   become: true  # This ensures all tasks are run with elevated privileges
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
 
     - name: Add IPv6 forwarding line to sysctl.d file (if IPv6 is enabled)

--- a/ansible/reset-nodes.yaml
+++ b/ansible/reset-nodes.yaml
@@ -3,7 +3,7 @@
   hosts: all
   become: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
   tasks:
     - name: Run kubeadm reset
       ansible.builtin.command:

--- a/ansible/trust-hosts.yaml
+++ b/ansible/trust-hosts.yaml
@@ -4,7 +4,7 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+    cluster_config: "{{ lookup('file', 'tmp/' ~ cluster_name ~ '/cluster_config.json') | from_json }}"
 
   tasks:
     - name: Iterate through all inventory hosts to update SSH keys

--- a/scripts/configure_secrets.sh
+++ b/scripts/configure_secrets.sh
@@ -47,8 +47,8 @@ tf_variables=(
     "proxmox_api_token|Enter the Proxmox API token in the following format: 'terraform@pve!provider=<token>'. The README guides you through making this token"
 #     "unifi_username|Enter the Unifi service account username. User must have 'Site Admin' permissions for the Network app"
 #     "unifi_password|Enter the Unifi service account password"
-#     "minio_access_key|Enter the MinIO access key"
-#     "minio_secret_key|Enter the MinIO secret key"
+    "minio_access_key|Enter the MinIO access key"
+    "minio_secret_key|Enter the MinIO secret key"
 )
 
 # Function to prompt and save secrets

--- a/scripts/k8s.env
+++ b/scripts/k8s.env
@@ -4,20 +4,20 @@
 
 NON_PASSWORD_PROTECTED_SSH_KEY="id_rsa" # assumed that this is in ~/.ssh/ and the .pub file is named similarly
 PROXMOX_USERNAME=root
-PROXMOX_HOST="10.0.0.100"
-PROXMOX_DISK_DATASTORE="local-btrfs"
-PROXMOX_BACKUPS_DATASTORE="hdds"
-PROXMOX_ISO_PATH="/var/lib/pve/local-btrfs/template/iso"
-TIMEZONE="America/Denver"
+PROXMOX_HOST="192.168.20.200"
+PROXMOX_DISK_DATASTORE="Samsung1TB-A"
+PROXMOX_BACKUPS_DATASTORE="backup"
+PROXMOX_ISO_PATH="/mnt/pve/data-hdd"
+TIMEZONE="America/Los_Angeles"
 TEMPLATE_VM_BRIDGE=vmbr0
-TEMPLATE_VM_GATEWAY="10.0.0.1"
-TEMPLATE_VM_IP="10.0.0.10/24"
-TEMPLATE_VM_SEARCH_DOMAIN="lan"
+TEMPLATE_VM_GATEWAY="192.168.20.1"
+TEMPLATE_VM_IP="192.168.20.240/24"
+TEMPLATE_VM_SEARCH_DOMAIN="brianbeck.net"
 TEMPLATE_VLAN_TAG="None" # None if no vlan, otherwise the vlan tag (e.g. 100)
-TWO_DNS_SERVERS="1.1.1.1 1.0.0.1"
-TEMPLATE_VM_CPU_TYPE="x86-64-v3"
-TEMPLATE_VM_CPU=8
-TEMPLATE_VM_MEM=8192
+TWO_DNS_SERVERS="192.168.20.201 192.168.20.202"
+TEMPLATE_VM_CPU_TYPE="x86-64-v2-AES"
+TEMPLATE_VM_CPU=4
+TEMPLATE_VM_MEM=16384
 
 ### -------------------------------------------------------
 ### --------------PKGS to Install with APT-----------------
@@ -25,17 +25,17 @@ TEMPLATE_VM_MEM=8192
 ### -----`apt-cache madison <package>` to find versions----
 ### -------------------------------------------------------
 
-KUBERNETES_SHORT_VERSION=1.32
-KUBERNETES_MEDIUM_VERSION=1.32.2
-KUBERNETES_LONG_VERSION=1.32.2-1.1
+KUBERNETES_SHORT_VERSION=1.35
+KUBERNETES_MEDIUM_VERSION=1.35.3
+KUBERNETES_LONG_VERSION=1.35.3-1.1
 
 # ------------------- Addon Versions ----------------------
 
-CILIUM_VERSION=1.16.6
-KUBELET_SERVING_CERT_APPROVER_VERSION=0.9.0
-LOCAL_PATH_PROVISIONER_VERSION=0.0.31
-METRICS_SERVER_VERSION=3.12.2
-METALLB_VERSION=0.14.9
+CILIUM_VERSION=1.19.2
+KUBELET_SERVING_CERT_APPROVER_VERSION=1.2.13
+LOCAL_PATH_PROVISIONER_VERSION=0.0.34
+METRICS_SERVER_VERSION=3.13.0
+METALLB_VERSION=0.15.3
 
 # ----------------NVIDIA Drivers (optional)----------------
 # To find versions on Ubuntu:
@@ -56,8 +56,8 @@ METALLB_VERSION=0.14.9
 ### -----Find these directly on GitHub Release Pages-------
 ### -------------------------------------------------------
 
-CNI_PLUGINS_VERSION=1.6.2
-ETCD_VERSION=3.5.19
+CNI_PLUGINS_VERSION=1.9.1
+ETCD_VERSION=3.6.9
 
 # The template vm's cpu/mem resources only matter for initial creation.
 # More cpu greatly speeds up nvidia driver installation.
@@ -73,13 +73,13 @@ ETCD_VERSION=3.5.19
 #   ansible will check to make sure there wasn't any disk space issues during the
 #   template creation process.
 
-### Debian 12 Image (Bookworm)
-TEMPLATE_VM_ID=9000
+### Debian 13 Image (Trixie)
+TEMPLATE_VM_ID=8000
 TEMPLATE_VM_NAME="k8s-ready-template"
-IMAGE_NAME="debian-12-generic-amd64.qcow2"
-IMAGE_LINK="https://cloud.debian.org/images/cloud/bookworm/latest/${IMAGE_NAME}"
-EXTRA_TEMPLATE_TAGS="bookworm template"
-TEMPLATE_DISK_SIZE=4.6G # Add 1.6G more if installing nvidia drivers
+IMAGE_NAME="debian-13-genericcloud-amd64.qcow2"
+IMAGE_LINK="https://cloud.debian.org/images/cloud/trixie/latest/${IMAGE_NAME}"
+EXTRA_TEMPLATE_TAGS="trixie template"
+TEMPLATE_DISK_SIZE=64G # Add 1.6G more if installing nvidia drivers
 
 ### Ubuntu 24.04 LTS Image (Noble Numbat)
 #TEMPLATE_VM_ID=9000

--- a/scripts/k8s_vm_template/FilesToPlace/apt-packages.sh
+++ b/scripts/k8s_vm_template/FilesToPlace/apt-packages.sh
@@ -42,6 +42,9 @@ apt-get update
 apt upgrade -y
 
 # Install packages from apt
+#software-properties-common \
+#intel-opencl-icd \
+
 apt install -y \
 bash \
 curl \
@@ -59,7 +62,6 @@ iperf \
 apt-transport-https \
 ca-certificates \
 gnupg-agent \
-software-properties-common \
 ipvsadm \
 apache2-utils \
 python3-kubernetes \
@@ -70,7 +72,6 @@ ceph \
 cron \
 iproute2 \
 intel-gpu-tools \
-intel-opencl-icd \
 helm \
 etcd-client \
 kubelet="$KUBERNETES_LONG_VERSION" \

--- a/terraform/clusters.tf
+++ b/terraform/clusters.tf
@@ -6,7 +6,7 @@ variable "clusters" {
     cluster_id               : number                                                     # Required. Acts as the vm_id and vlan prefix. This plus the vm start ip should always be over 100 because of how proxmox likes its vmids.
     kubeconfig_file_name     : string                                                     # Required. Name of the local kubeconfig file to be created. Assumed this will be in $HOME/.kube/
     start_on_proxmox_boot    : optional(bool, true)                                       # Optional. Whether or not to start the cluster's vms on proxmox boot
-    max_pods_per_node        : optional(number, 512)                                      # Optional. Max pods per node. This should be a function of the quantity of IPs in you pod_cidr and number of nodes.
+    max_pods_per_node        : optional(number, 64)                                      # Optional. Max pods per node. This should be a function of the quantity of IPs in you pod_cidr and number of nodes.
     reboot_after_update      : optional(bool, false)                                      # Optional. Whether or not to reboot the nodes during terraform apply.
     use_pve_ha               : optional(bool, false)                                      # Optional. Whether to setup PVE High Availability for the VMs.
     ssh                      : object({
@@ -22,12 +22,12 @@ variable "clusters" {
       vlan_id                : optional(number, null)                                     # Optional. The vlan id to assign to the network interfaces of the VMs. Defaults to <cluster_id>00 (e.e. 100, 200, 300, etc.)
       vlan_name              : optional(string, null)                                     # Optional. The name of the VLAN in Unifi. Defaults to the cluster name in all caps.
       ipv4                   : object({
-        subnet_prefix        : optional(string, "10.0.0")                                 # Optional. First three octets of the host IPv4 network's subnet (assuming its a /24)
-        gateway              : optional(string, "10.0.0.1")                               # Optional. Gateway for vm hosts
-        pod_cidr             : optional(string, "10.42.0.0/16")                           # Optional. Cidr range for pod networking internal to cluster. Shouldn't overlap with ipv4 lan network. These must differ cluster to cluster if using clustermesh.
-        svc_cidr             : optional(string, "10.43.0.0/16")                           # Optional. Cidr range for service networking internal to cluster. Shouldn't overlap with ipv4 lan network.
-        dns1                 : optional(string, "1.1.1.1")                                # Optional. Primary dns server for vm hosts
-        dns2                 : optional(string, "1.0.0.1")                                # Optional. Secondary dns server for vm hosts
+        subnet_prefix        : optional(string, "192.168.20")                                 # Optional. First three octets of the host IPv4 network's subnet (assuming its a /24)
+        gateway              : optional(string, "192.168.20.1")                               # Optional. Gateway for vm hosts
+        pod_cidr             : optional(string, "10.80.0.0/16")                           # Optional. Cidr range for pod networking internal to cluster. Shouldn't overlap with ipv4 lan network. These must differ cluster to cluster if using clustermesh.
+        svc_cidr             : optional(string, "10.81.0.0/16")                           # Optional. Cidr range for service networking internal to cluster. Shouldn't overlap with ipv4 lan network.
+        dns1                 : optional(string, "192.168.20.201")                                # Optional. Primary dns server for vm hosts
+        dns2                 : optional(string, "192.168.20.202")                                # Optional. Secondary dns server for vm hosts
         management_cidrs     : optional(string, "")                                       # Optional. Proxmox list of ipv4 IPs or cidrs that you want to be able to reach the K8s api and ssh into the hosts. Only used if use_pve_firewall is true.
         lb_cidrs             : string                                                     # Required. IPv4 cidrs to use for MetalLB.
       })
@@ -44,7 +44,7 @@ variable "clusters" {
         lb_cidrs             : optional(string, "")                                       # Optional. IPv6 cidrs to use for MetalLB. Required if IPv6 is enabled.
       })
       kube_vip               : object({
-        kube_vip_version     : optional(string, "0.8.4")                                  # Optional. Kube-vip version to use. Needs to be their ghcr.io docker image version
+        kube_vip_version     : optional(string, "1.1.1")                                  # Optional. Kube-vip version to use. Needs to be their ghcr.io docker image version
         vip_interface        : optional(string, "eth0")                                   # Optional. Interface that faces the local lan. Usually eth0 for this project.
         vip                  : string                                                     # Required. IP address of the highly available kubernetes control plane.
         vip_hostname         : string                                                     # Required. Hostname to use when querying the api server's vip load balancer (kube-vip)
@@ -55,7 +55,7 @@ variable "clusters" {
       count                  : number                                                     # Required. Number of VMs to create for this node class.
       pve_nodes              : optional(list(string),["Citadel","Acropolis","Parthenon"]) # Optional. Nodes that this class is allowed to run on. They will be cycled through and will repeat if count > length(pve_nodes).
       machine                : optional(string, "q35")                                    # Optional. Default to "q35". Use i400fx for partial gpu pass-through.
-      cpu_type               : optional(string, "x86-64-v3")                              # Optional. Default to x86-64-v3. 'host' gives the best performance and is needed for full gpu pass-through, but it can't live migrate. https://www.yinfor.com/2023/06/how-i-choose-vm-cpu-type-in-proxmox-ve.html
+      cpu_type               : optional(string, "x86-64-v2-AES")                              # Optional. Default to x86-64-v3. 'host' gives the best performance and is needed for full gpu pass-through, but it can't live migrate. https://www.yinfor.com/2023/06/how-i-choose-vm-cpu-type-in-proxmox-ve.html
       cores                  : optional(number, 2)                                        # Optional. Number of cores to use.
       sockets                : optional(number, 1)                                        # Optional. Number of sockets to use or emulate.
       memory                 : optional(number, 2048)                                     # Optional. Non-ballooning memory in MB.
@@ -78,162 +78,236 @@ variable "clusters" {
     }))
   }))
   default = { # create your clusters here using the above object
-    "alpha" = {
-      cluster_name             = "alpha"
+    "beck-prod" = {
+      cluster_name             = "beck-prod"
       cluster_id               = 1
-      kubeconfig_file_name     = "alpha.yml"
-      start_on_proxmox_boot    = false
+      kubeconfig_file_name     = "beck-prod.yml"
+      start_on_proxmox_boot    = true
       ssh = {
-        ssh_user               = "line6"
+        ssh_user               = "beck"
       }
       networking = {
         ipv4 = {
-          subnet_prefix        = "10.0.1"
-          gateway              = "10.0.1.1"
+          subnet_prefix        = "192.168.20"
+          gateway              = "192.168.20.1"
+          dns1                 = "192.168.20.201"
+          dns2                 = "192.168.20.202"
           management_cidrs     = "10.0.0.0/30,10.0.60.2,10.0.50.5,10.0.50.6"
-          lb_cidrs             = "10.0.1.200/29,10.0.1.208/28,10.0.1.224/28,10.0.1.240/29,10.0.1.248/30,10.0.1.252/31"
+          lb_cidrs             = "192.168.20.224/29"
+          pod_cidr             = "10.80.0.0/16"
+          svc_cidr             = "10.81.0.0/16"
         }
         ipv6 = {}
         kube_vip = {
-          vip                  = "10.0.1.100"
-          vip_hostname         = "alpha-api-server"
+          kube_vip_version     = "1.1.1"
+          vip_interface        = "eth0"
+          vip                  = "192.168.20.250"
+          vip_hostname         = "beck-prod-api-server"
+          use_ipv6             = false
         }
       }
       node_classes = {
         controlplane = {
           count      = 1
-          cores      = 16
+          pve_nodes  = ["pve"]
+          cpu_type   = "x86-64-v2-AES"
+          cores      = 2 
+          sockets    = 1
+          memory     = 8192
+          disks      = [
+            { 
+              datastore  = "Samsung1TB-A" 
+              size       = 64 
+              backup     = true
+              cache_mode = "none"
+              aio_mode   = "io_uring"
+            }
+          ]
+          start_ip   = 240
+          labels  = [
+            "nodeclass=controlplane"
+          ]
+          taints  = []
+          devices = []
+        }
+        general = {
+          count      = 2
+          pve_nodes  = ["pve"]
+          machine    = "q35"
+          cpu_type   = "x86-64-v2-AES"
+          cores      = 4
+          sockets    = 1
           memory     = 16384
           disks      = [
-            { datastore = "local-btrfs", size = 100 }
+            {
+              datastore  = "Samsung1TB-A"
+              size       = 64
+              backup     = true
+              cache_mode = "none"
+              aio_mode   = "io_uring"
+            }
           ]
-          start_ip   = 110
+          start_ip   = 242
           labels = [
-            "nodeclass=controlplane"
+            "nodeclass=general"
           ]
+          taints  = []
+          devices = []
         }
       }
     }
-    "beta" = {
-      cluster_name             = "beta"
+
+    "beck-stage" = {
+      cluster_name             = "beck-stage"
       cluster_id               = 2
-      kubeconfig_file_name     = "beta.yml"
-      start_on_proxmox_boot    = false
+      kubeconfig_file_name     = "beck-stage.yml"
+      start_on_proxmox_boot    = true
       ssh = {
-        ssh_user               = "line6"
+        ssh_user               = "beck"
       }
       networking = {
         ipv4 = {
-          subnet_prefix        = "10.0.2"
-          gateway              = "10.0.2.1"
-          management_cidrs     = "10.0.0.0/30,10.0.60.2,10.0.50.5,10.0.50.6"
-          lb_cidrs             = "10.0.2.200/29,10.0.2.208/28,10.0.2.224/28,10.0.2.240/29,10.0.2.248/30,10.0.2.252/31"
+          subnet_prefix        = "192.168.20"
+          gateway              = "192.168.20.1"
+          dns1                 = "192.168.20.201"
+          dns2                 = "192.168.20.202"
+          management_cidrs     = "10.1.0.0/30,10.0.61.2,10.0.51.5,10.0.51.6"
+          lb_cidrs             = "192.168.20.232/29"
+          pod_cidr             = "10.82.0.0/16"
+          svc_cidr             = "10.83.0.0/16"
         }
         ipv6 = {}
         kube_vip = {
-          vip                  = "10.0.2.100"
-          vip_hostname         = "beta-api-server"
+          kube_vip_version     = "1.1.1"
+          vip_interface        = "eth0"
+          vip                  = "192.168.20.251"
+          vip_hostname         = "beck-stage-api-server"
+          use_ipv6             = false
         }
       }
       node_classes = {
         controlplane = {
           count      = 1
+          pve_nodes  = ["pve"]
+          cpu_type   = "x86-64-v2-AES"
+          cores      = 2 
+          sockets    = 1
+          memory     = 8192
+          disks      = [
+            { 
+              datastore  = "Samsung1TB-A" 
+              size       = 64 
+              backup     = true
+              cache_mode = "none"
+              aio_mode   = "io_uring"
+            }
+          ]
+          start_ip   = 241
+          labels  = [
+            "nodeclass=controlplane"
+          ]
+          taints  = []
+          devices = []
+        }
+        general = {
+          count      = 2
+          pve_nodes  = ["pve"]
+          machine    = "q35"
+          cpu_type   = "x86-64-v2-AES"
           cores      = 4
-          memory     = 4096
+          sockets    = 1
+          memory     = 16384
           disks      = [
-            { datastore = "local-btrfs", size = 20 }
+            {
+              datastore  = "Samsung1TB-A"
+              size       = 64
+              backup     = true
+              cache_mode = "none"
+              aio_mode   = "io_uring"
+            }
           ]
-          start_ip   = 110
-          labels = [
-            "nodeclass=controlplane"
-          ]
-        }
-        general = {
-          count      = 2
-          cores      = 8
-          memory     = 4096
-          disks      = [
-            { datastore = "local-btrfs", size = 20 }
-          ]
-          start_ip   = 130
+          start_ip   = 245
           labels = [
             "nodeclass=general"
           ]
+          taints  = []
+          devices = []
         }
       }
     }
-    "gamma" = {
-      cluster_name             = "gamma"
-      cluster_id               = 3
-      kubeconfig_file_name     = "gamma.yml"
-      start_on_proxmox_boot    = false
-      ssh = {
-        ssh_user               = "line6"
-      }
-      networking = {
-        ipv4 = {
-          subnet_prefix        = "10.0.3"
-          gateway              = "10.0.3.1"
-          management_cidrs     = "10.0.0.0/30,10.0.60.2,10.0.50.5,10.0.50.6"
-          lb_cidrs             = "10.0.3.200/29,10.0.3.208/28,10.0.3.224/28,10.0.3.240/29,10.0.3.248/30,10.0.3.252/31"
-        }
-        ipv6 = {}
-        kube_vip = {
-          vip                  = "10.0.3.100"
-          vip_hostname         = "gamma-api-server"
-        }
-      }
-      node_classes = {
-        controlplane = {
-          count     = 3
-          cores     = 4
-          memory    = 4096
-          disks     = [
-            { datastore = "local-btrfs", size = 20 }
-          ]
-          start_ip = 110
-          labels   = [
-            "nodeclass=controlplane"
-          ]
-        }
-        etcd = {
-          count     = 3
-          disks     = [
-            { datastore = "local-btrfs", size = 20 }
-          ]
-          start_ip = 120
-        }
-        general = {
-          count     = 5
-          cores     = 8
-          memory    = 4096
-          disks     = [
-            { datastore = "local-btrfs", size = 20 }
-          ]
-          start_ip = 130
-          labels   = [
-            "nodeclass=general"
-          ]
-        }
-        gpu = {
-          count      = 2
-          pve_nodes  = [ "Acropolis", "Parthenon" ]
-          cpu_type   = "host"
-          disks      = [
-            { datastore = "local-btrfs", size = 20 }
-          ]
-          start_ip   = 190
-          labels = [
-            "nodeclass=gpu"
-          ]
-          taints  = [
-            "gpu=true:NoSchedule"
-          ]
-          devices = [
-            { mapping = "my-full-gpu-passthrough" }
-          ]
-        }
-      }
-    }
+
+#    "gamma" = {
+#      cluster_name             = "gamma"
+#      cluster_id               = 3
+#      kubeconfig_file_name     = "gamma.yml"
+#      start_on_proxmox_boot    = false
+#      ssh = {
+#        ssh_user               = "line6"
+#      }
+#      networking = {
+#        ipv4 = {
+#          subnet_prefix        = "10.0.3"
+#          gateway              = "10.0.3.1"
+#          management_cidrs     = "10.0.0.0/30,10.0.60.2,10.0.50.5,10.0.50.6"
+#          lb_cidrs             = "10.0.3.200/29,10.0.3.208/28,10.0.3.224/28,10.0.3.240/29,10.0.3.248/30,10.0.3.252/31"
+#        }
+#        ipv6 = {}
+#        kube_vip = {
+#          vip                  = "10.0.3.100"
+#          vip_hostname         = "gamma-api-server"
+#        }
+#      }
+#      node_classes = {
+#        controlplane = {
+#          count     = 3
+#          cores     = 4
+#          memory    = 4096
+#          disks     = [
+#            { datastore = "Samsung1TB-A", size = 20 }
+#          ]
+#          start_ip = 110
+#          labels   = [
+#            "nodeclass=controlplane"
+#          ]
+#        }
+#        etcd = {
+#          count     = 3
+#          disks     = [
+#            { datastore = "Samsung1TB-A", size = 20 }
+#          ]
+#          start_ip = 120
+#        }
+#        general = {
+#          count     = 5
+#          cores     = 8
+#          memory    = 4096
+#          disks     = [
+#            { datastore = "Samsung1TB-A", size = 20 }
+#          ]
+#          start_ip = 130
+#          labels   = [
+#            "nodeclass=general"
+#          ]
+#        }
+#        gpu = {
+#          count      = 2
+#          pve_nodes  = [ "pve" ]
+#          cpu_type   = "host"
+#          disks      = [
+#            { datastore = "Samsung1TB-A", size = 20 }
+#          ]
+#          start_ip   = 190
+#          labels = [
+#            "nodeclass=gpu"
+#          ]
+#          taints  = [
+#            "gpu=true:NoSchedule"
+#          ]
+#          devices = [
+#            { mapping = "my-full-gpu-passthrough" }
+#          ]
+#        }
+#      }
+#    }
   }
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-#     aws = {
-#       source  = "hashicorp/aws"
-#       version = "5.90.0"
-#     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.37.0"
+    }
     proxmox = {
       source  = "bpg/proxmox"
-      version = "0.73.1"
+      version = "0.99.0"
     }
 #     unifi = {
 #       source  = "paultyng/unifi"
@@ -14,40 +14,40 @@ terraform {
 #     }
   }
 
-#   backend "s3" {
-#     bucket     = local.minio_bucket
-#     key        = "cluster_creator.tfstate"
-#     region     = local.minio_region
-#     access_key = var.minio_access_key
-#     secret_key = var.minio_secret_key
-# 
-#     endpoints = {
-#       s3 = local.minio_endpoint
-#     }
-# 
-#     use_path_style              = true
-#     skip_credentials_validation = true
-#     skip_metadata_api_check     = true
-#     skip_region_validation      = true
-#     skip_requesting_account_id  = true
-#   }
+  backend "s3" {
+    bucket     = local.minio_bucket
+    key        = "cluster_creator.tfstate"
+    region     = local.minio_region
+    access_key = var.minio_access_key
+    secret_key = var.minio_secret_key
+
+    endpoints = {
+      s3 = local.minio_endpoint
+    }
+
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+  }
 }
 
-# provider "aws" {
-#   region     = local.minio_region
-#   access_key = var.minio_access_key
-#   secret_key = var.minio_secret_key
-# 
-#   endpoints {
-#     s3 = local.minio_endpoint
-#   }
-# 
-#   skip_credentials_validation = true
-#   skip_metadata_api_check     = true
-#   skip_region_validation      = true
-#   skip_requesting_account_id  = true
-#   s3_use_path_style           = true
-# }
+provider "aws" {
+  region     = local.minio_region
+  access_key = var.minio_access_key
+  secret_key = var.minio_secret_key
+
+  endpoints {
+    s3 = local.minio_endpoint
+  }
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+  s3_use_path_style           = true
+}
 
 # provider "unifi" {
 #   username       = var.unifi_username
@@ -56,9 +56,11 @@ terraform {
 #   allow_insecure = true
 # }
 
+#api_token  = var.proxmox_api_token
 provider "proxmox" {
   endpoint   = "https://${local.proxmox_host}:8006/api2/json"
-  api_token  = var.proxmox_api_token
+  username   = var.proxmox_username
+  api_token = "${var.proxmox_username}@pve!provider=${var.proxmox_api_token}"
   ssh {
     username = var.proxmox_username
     agent    = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,9 +1,9 @@
 locals {
-    proxmox_host   = "10.0.0.100"
-    proxmox_node   = "Citadel"
-    template_vm_id = 9000
+    proxmox_host   = "192.168.20.200"
+    proxmox_node   = "pve"
+    template_vm_id = 8000
 #     unifi_api_url  = "https://10.0.0.1/"
-#     minio_endpoint = "https://s3.christensencloud.us"
-#     minio_region   = "default"
-#     minio_bucket   = "terraform-state"
+    minio_endpoint = "http://192.168.20.191:9000"
+    minio_region   = "default"
+    minio_bucket   = "terraform-state"
 }


### PR DESCRIPTION
Updates include: 

1. Fix Ansible deprecation warnings
2. Add logic to check if kubeadm init has been run to prevent re-running and allow continuing the bootstrap process
3. Changing the kubelet cert server install script URL to: "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml"
4. Removed displaying the etcd encryption key and instead displaying that is has been set.
5. Changed the kubectl use-context command to match the name string :
    cmd: kubectl config use-context {{ cluster_config.cluster_name }}-admin@{{ cluster_config.cluster_name }}

Example Ansible Deprecation Warning:

WARNING]: Jinja constant strings should not contain embedded templates. This feature will be disabled by default in ansible-core 2.23.
Origin: /Users/beck/src/ClusterCreator/ansible/join-worker-nodes.yaml:125:29