### PR TITLE
Fix k8s upgrade playbooks for encryption and package ordering

### DIFF
--- a/ansible/etcd-encryption.yaml
+++ b/ansible/etcd-encryption.yaml
@@ -145,11 +145,13 @@
       when: config_check.rc != 0
       retries: 3
 
-    - name: Make encryption manifest edit script executable
-      ansible.builtin.file:
-        path: /usr/local/bin/encryption-manifest-edit.sh
+    - name: Deploy encryption manifest edit script
+      ansible.builtin.copy:
+        src: ../scripts/k8s_vm_template/FilesToPlace/encryption-manifest-edit.sh
+        dest: /usr/local/bin/encryption-manifest-edit.sh
         mode: "0755"
-        state: file
+        owner: root
+        group: root
 
     - name: Set up cron job for encryption manifest edit script
       ansible.builtin.cron:

--- a/ansible/helpers/etcd_encryption_configuration.yaml.j2
+++ b/ansible/helpers/etcd_encryption_configuration.yaml.j2
@@ -5,8 +5,7 @@ resources:
   - resources:
       # Resources to encrypt - remember this only works for new objects, not existing ones, so you'll need to replace your existing objects with new ones.
       #   For that reason, you may not want to put a "*" in here if you ever need to decrypt existing objects.
-      - secrets
-      - configmaps
+      - '*.*'  # all resources, even custom ones
     providers:
       # Encrypt with this key for all new objects
       - aescbc:

--- a/ansible/upgrade-k8s-cluster.yaml
+++ b/ansible/upgrade-k8s-cluster.yaml
@@ -34,12 +34,10 @@
         state: present
         filename: "kubernetes"
 
-    - name: Install specific versions of kubelet, kubeadm, kubectl
+    - name: Install kubeadm
       ansible.builtin.apt:
         name:
-          - "kubelet={{ kubernetes_long_version }}"
           - "kubeadm={{ kubernetes_long_version }}"
-          - "kubectl={{ kubernetes_long_version }}"
         state: present
         allow_change_held_packages: true
         allow_downgrade: true
@@ -67,21 +65,68 @@
         msg: "User chose not to continue."
       when: "user_confirmation.user_input | lower != 'yes'"
 
+    - name: Check if etcd encryption is configured in apiserver manifest
+      ansible.builtin.shell: >
+        grep -q 'encryption-provider-config' /etc/kubernetes/manifests/kube-apiserver.yaml
+      register: encryption_check
+      failed_when: false
+      changed_when: false
+
+    - name: Add encryption config to kubeadm-config ConfigMap
+      when: encryption_check.rc == 0
+      delegate_to: localhost
+      become: false
+      block:
+        - name: Check if kubeadm-config already has encryption config
+          ansible.builtin.shell: >
+            kubectl get configmap kubeadm-config -n kube-system
+            -o jsonpath='{.data.ClusterConfiguration}' | grep -q 'encryption-provider-config'
+          register: configmap_encryption_check
+          failed_when: false
+          changed_when: false
+
+        - name: Patch kubeadm-config with encryption extraArgs and extraVolumes
+          when: configmap_encryption_check.rc != 0
+          ansible.builtin.shell: |
+            # Get current config YAML, add encryption args/volumes, output as YAML
+            PATCHED=$(kubectl get configmap kubeadm-config -n kube-system \
+              -o jsonpath='{.data.ClusterConfiguration}' | yq -y '
+                .apiServer.extraArgs = (.apiServer.extraArgs // []) +
+                  [{"name": "encryption-provider-config", "value": "/etc/kubernetes/enc/enc.yaml"}] |
+                .apiServer.extraVolumes = (.apiServer.extraVolumes // []) +
+                  [{"name": "enc", "hostPath": "/etc/kubernetes/enc", "mountPath": "/etc/kubernetes/enc",
+                    "readOnly": true, "pathType": "DirectoryOrCreate"}]
+              ')
+
+            # Update the ConfigMap
+            kubectl get configmap kubeadm-config -n kube-system -o json | \
+              jq --arg config "$PATCHED" '.data.ClusterConfiguration = $config' | \
+              kubectl replace -f -
+          register: patch_result
+
+        - name: Show kubeadm-config patch result
+          ansible.builtin.debug:
+            msg: "{{ patch_result.stdout | default('Encryption config already present in kubeadm-config ConfigMap') }}"
+
     - name: Kubeadm Upgrade Apply
       ansible.builtin.shell:
         cmd: >
-          # K8s documentation recommends this step
-          killall -s SIGTERM kube-apiserver # trigger a graceful kube-apiserver shutdown
-          sleep 20 # wait a little bit to permit completing in-flight requests
-          
           kubeadm upgrade apply v{{ kubernetes_medium_version }} -y
-      ignore_errors: true
       delegate_to: "{{ inventory_hostname }}"
       register: upgrade_output
 
     - name: Show upgrade output
       ansible.builtin.debug:
         msg: "{{ upgrade_output.stdout.splitlines() }}"
+
+    - name: Install kubelet and kubectl
+      ansible.builtin.apt:
+        name:
+          - "kubelet={{ kubernetes_long_version }}"
+          - "kubectl={{ kubernetes_long_version }}"
+        state: present
+        allow_change_held_packages: true
+        allow_downgrade: true
 
     - name: Reload systemd daemon
       ansible.builtin.systemd:

--- a/ansible/upgrade-k8s-packages.yaml
+++ b/ansible/upgrade-k8s-packages.yaml
@@ -34,12 +34,10 @@
         state: present
         filename: "kubernetes"
 
-    - name: Install specific versions of kubelet, kubeadm, kubectl
+    - name: Install kubeadm
       ansible.builtin.apt:
         name:
-          - "kubelet={{ kubernetes_long_version }}"
           - "kubeadm={{ kubernetes_long_version }}"
-          - "kubectl={{ kubernetes_long_version }}"
         state: present
         allow_change_held_packages: true
         allow_downgrade: true
@@ -64,11 +62,62 @@
       ansible.builtin.meta: end_host
       when: "'etcd' in groups and 'etcd' in group_names"
 
+    - name: Check if etcd encryption is configured in apiserver manifest
+      ansible.builtin.shell: >
+        grep -q 'encryption-provider-config' /etc/kubernetes/manifests/kube-apiserver.yaml
+      register: encryption_check
+      failed_when: false
+      changed_when: false
+
+    - name: Add encryption config to kubeadm-config ConfigMap
+      when: encryption_check.rc == 0
+      delegate_to: localhost
+      become: false
+      block:
+        - name: Check if kubeadm-config already has encryption config
+          ansible.builtin.shell: >
+            kubectl get configmap kubeadm-config -n kube-system
+            -o jsonpath='{.data.ClusterConfiguration}' | grep -q 'encryption-provider-config'
+          register: configmap_encryption_check
+          failed_when: false
+          changed_when: false
+
+        - name: Patch kubeadm-config with encryption extraArgs and extraVolumes
+          when: configmap_encryption_check.rc != 0
+          ansible.builtin.shell: |
+            # Get current config YAML, add encryption args/volumes, output as YAML
+            PATCHED=$(kubectl get configmap kubeadm-config -n kube-system \
+              -o jsonpath='{.data.ClusterConfiguration}' | yq -y '
+                .apiServer.extraArgs = (.apiServer.extraArgs // []) +
+                  [{"name": "encryption-provider-config", "value": "/etc/kubernetes/enc/enc.yaml"}] |
+                .apiServer.extraVolumes = (.apiServer.extraVolumes // []) +
+                  [{"name": "enc", "hostPath": "/etc/kubernetes/enc", "mountPath": "/etc/kubernetes/enc",
+                    "readOnly": true, "pathType": "DirectoryOrCreate"}]
+              ')
+
+            # Update the ConfigMap
+            kubectl get configmap kubeadm-config -n kube-system -o json | \
+              jq --arg config "$PATCHED" '.data.ClusterConfiguration = $config' | \
+              kubectl replace -f -
+          register: patch_result
+
+        - name: Show kubeadm-config patch result
+          ansible.builtin.debug:
+            msg: "{{ patch_result.stdout | default('Encryption config already present in kubeadm-config ConfigMap') }}"
+
     - name: Kubeadm Upgrade Node
       ansible.builtin.shell:
         cmd: >
           kubeadm upgrade node
-      ignore_errors: true
+
+    - name: Install kubelet and kubectl
+      ansible.builtin.apt:
+        name:
+          - "kubelet={{ kubernetes_long_version }}"
+          - "kubectl={{ kubernetes_long_version }}"
+        state: present
+        allow_change_held_packages: true
+        allow_downgrade: true
 
     - name: Reload systemd daemon
       ansible.builtin.systemd:


### PR DESCRIPTION
This makes the etcd changes in the `development` branch compatible with clusters created using the playbooks on `main`.

It also fixes a bug with `ccr upgrade-k8s` and `ccr upgrade-node` where upgrading `kubeadm` and `kubelet` at the same time could trigger a race condition, causing many pods in `kube-system` to go into `CrashLoopBackOff`. So now `kubeadm` is upgraded first, and `kubelet` is updated only after it's successful.

Finally, killing `apiserver` before `kubeadm upgrade` is also race-y (another source of `CrashLoopBackOff`s) but it's also unnecessary as `kubeadm upgrade` handles that internally.

I tested this extensively on a cluster with 3 controlplane nodes, and I believe I covered every edge-case.

Fixes #62