### PR TITLE
Fix double reboot on kernel upgrade and add kernel version pinning

### DIFF
--- a/ansible/upgrade-apt.yaml
+++ b/ansible/upgrade-apt.yaml
@@ -6,6 +6,22 @@
   any_errors_fatal: true
 
   tasks:
+    - name: Sync k8s.env to node
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../scripts/k8s.env"
+        dest: /etc/k8s.env
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Sync extra-kernel-modules.sh to node
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../scripts/k8s_vm_template/FilesToPlace/extra-kernel-modules.sh"
+        dest: /root/extra-kernel-modules.sh
+        owner: root
+        group: root
+        mode: '0755'
+
     - name: Upgrade all packages to the latest version
       become: true
       ansible.builtin.apt:
@@ -18,10 +34,95 @@
       until: upgrade_result is succeeded
       retries: 30
       delay: 10
+
+    - name: Install linux-modules-extra for all installed kernels
+      ansible.builtin.shell: |
+        for kernel in $(dpkg --list | grep -oP '^ii\s+linux-image-\K[0-9][^\s]+'); do
+          pkg="linux-modules-extra-${kernel}"
+          if dpkg -l "$pkg" 2>/dev/null | grep -q '^ii'; then
+            echo "$pkg already installed"
+          else
+            echo "Installing $pkg"
+            apt-get install -y "$pkg"
+          fi
+        done
+      register: modules_result
+      changed_when: "'Installing' in modules_result.stdout"
+
+    # Workaround for broken Ubuntu 6.8.0-* kernels (e.g. 6.8.0-100, 6.8.0-101)
+    # that randomly drop UDP packets. This wreaks havoc in K8s — Cilium goes
+    # into CrashLoopBackOff, which in turn kills other pods on the node as
+    # they lose networking.
+    # See: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2141531
+    #
+    # If the newest installed kernel is in the same major.minor.patch series
+    # as the pinned version (e.g. both 6.8.0-*), GRUB is set to boot the
+    # pinned kernel. Otherwise — pinning disabled, or a jump to a new series
+    # (e.g. 6.8.1, 6.12) — GRUB_DEFAULT is reset to 0 so the node goes back to
+    # booting the newest kernel. The reset matters: without it, a node pinned
+    # by an earlier run keeps booting the pinned kernel forever, even after
+    # PINNED_KERNEL_VERSION is set to "none".
+    - name: Set kernel boot preference
+      block:
+        - name: Get the newest installed kernel version
+          ansible.builtin.shell: |
+            dpkg --list | grep -oP '^ii\s+linux-image-\K[0-9][^\s]+' | sort -V | tail -1
+          register: newest_kernel
+          changed_when: false
+
+        - name: Extract major.minor.patch from pinned and newest kernels
+          ansible.builtin.set_fact:
+            pinned_series: "{{ pinned_kernel_version | regex_replace('^(\\d+\\.\\d+\\.\\d+).*', '\\1') }}"
+            newest_series: "{{ newest_kernel.stdout | regex_replace('^(\\d+\\.\\d+\\.\\d+).*', '\\1') }}"
+
+        - name: Determine if kernel pinning applies
+          ansible.builtin.set_fact:
+            kernel_pin_active: "{{ pinned_kernel_version != 'none' and pinned_series == newest_series }}"
+
+        - name: Get filesystem UUID for GRUB menu entry
+          ansible.builtin.shell: |
+            findmnt -no UUID /
+          register: root_uuid
+          changed_when: false
+          when: kernel_pin_active
+
+        - name: Set GRUB default to pinned kernel
+          ansible.builtin.lineinfile:
+            path: /etc/default/grub
+            regexp: '^GRUB_DEFAULT='
+            line: 'GRUB_DEFAULT="gnulinux-advanced-{{ root_uuid.stdout }}>gnulinux-{{ pinned_kernel_version }}-advanced-{{ root_uuid.stdout }}"'
+          register: grub_pinned
+          when: kernel_pin_active
+
+        # Undo any pin left behind by an earlier run. 0 is the stock Ubuntu
+        # value and boots the first menu entry, i.e. the newest kernel.
+        - name: Reset GRUB default to the newest kernel
+          ansible.builtin.lineinfile:
+            path: /etc/default/grub
+            regexp: '^GRUB_DEFAULT='
+            line: 'GRUB_DEFAULT=0'
+          register: grub_unpinned
+          when: not kernel_pin_active
+
+        - name: Update GRUB configuration
+          ansible.builtin.command: update-grub
+          when: grub_pinned.changed | default(false) or grub_unpinned.changed | default(false)
+
+        - name: Log kernel pin status
+          ansible.builtin.debug:
+            msg: >-
+              {% if kernel_pin_active %}
+              Kernel pinned to {{ pinned_kernel_version }} (newest installed: {{ newest_kernel.stdout }}, same {{ pinned_series }} series).
+              {% elif pinned_kernel_version == 'none' %}
+              Kernel pinning disabled. Booting the newest installed kernel ({{ newest_kernel.stdout }}).
+              {% else %}
+              Kernel pin not applied — newest kernel {{ newest_kernel.stdout }} is in a different series ({{ newest_series }}) than pin ({{ pinned_series }}). Booting newest kernel.
+              {% endif %}
+
     - name: Reboot the node
       become: true
       ansible.builtin.reboot:
-        msg: "Rebooting because k8s package upgrades sometimes require a reboot (e.g. the CNI)"
+        msg: "Rebooting after apt upgrade"
         connect_timeout: 5
         reboot_timeout: 600
         pre_reboot_delay: 0

--- a/clustercreator.sh
+++ b/clustercreator.sh
@@ -109,6 +109,7 @@ run_playbooks() {
     -e local_path_provisioner_version="$LOCAL_PATH_PROVISIONER_VERSION"
     -e metrics_server_version="$METRICS_SERVER_VERSION"
     -e kubelet_serving_cert_approver_version="$KUBELET_SERVING_CERT_APPROVER_VERSION"
+    -e pinned_kernel_version="${PINNED_KERNEL_VERSION:-none}"
   )
 
   # Separate playbooks from extra_vars

--- a/scripts/k8s.env
+++ b/scripts/k8s.env
@@ -20,6 +20,28 @@ TEMPLATE_VM_CPU=8
 TEMPLATE_VM_MEM=8192
 
 ### -------------------------------------------------------
+### ------------------Kernel Pinning-----------------------
+### -------------------------------------------------------
+
+# Pin to a known-good kernel to work around broken Ubuntu 6.8.0-*
+# releases that randomly drop UDP packets, which sends Cilium into
+# CrashLoopBackOff and takes networking down for other pods on the node.
+# See: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2141531
+#
+# If the newest installed kernel shares the same major.minor.patch
+# (e.g. 6.8.0) as the pinned version, the system will boot the
+# pinned kernel instead. A jump to a new series (e.g. 6.8.1, 6.12)
+# is allowed automatically. Set to "none" to disable pinning.
+#
+# Note that Ubuntu 24.04's GA kernel stays on 6.8.0 for the life of the
+# release (only the ABI suffix moves, e.g. -106 -> -136); new series only
+# arrive via the HWE metapackages, which this project does not install.
+# So on 24.04 the series check never lapses on its own — clearing the pin
+# is a manual edit here. Changing this to "none" resets GRUB on the next
+# `ccr upgrade-node` run.
+# PINNED_KERNEL_VERSION=6.8.0-106-generic
+
+### -------------------------------------------------------
 ### --------------PKGS to Install with APT-----------------
 ### ---kubectl, kubeadm, and kubelet use the k8s version---
 ### -----`apt-cache madison <package>` to find versions----

--- a/scripts/k8s_vm_template/FilesToPlace/extra-kernel-modules.sh
+++ b/scripts/k8s_vm_template/FilesToPlace/extra-kernel-modules.sh
@@ -1,7 +1,33 @@
 #!/usr/bin/env bash
 
-# Define the package for the current kernel
+# Workaround for broken Ubuntu 6.8.0-* kernels that randomly drop UDP packets,
+# sending Cilium into CrashLoopBackOff and taking networking down for other pods
+# on the node. See: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2141531
+#
+# Read pinned kernel version from k8s.env if available
+PINNED_KERNEL_VERSION="none"
+if [[ -f /etc/k8s.env ]]; then
+  pinned=$(grep -oP '^PINNED_KERNEL_VERSION=\K.*' /etc/k8s.env 2>/dev/null)
+  if [[ -n "$pinned" ]]; then
+    PINNED_KERNEL_VERSION="$pinned"
+  fi
+fi
+
 current_kernel_version=$(uname -r)
+
+# If a kernel is pinned and we booted into a different kernel in the same
+# series (e.g. 6.8.0-107 instead of pinned 6.8.0-106), skip installing
+# modules for the wrong kernel — just log and exit. The GRUB default
+# should already point to the pinned kernel; a reboot will fix it.
+if [[ "$PINNED_KERNEL_VERSION" != "none" && "$current_kernel_version" != "$PINNED_KERNEL_VERSION" ]]; then
+  pinned_series=$(echo "$PINNED_KERNEL_VERSION" | grep -oP '^\d+\.\d+\.\d+')
+  current_series=$(echo "$current_kernel_version" | grep -oP '^\d+\.\d+\.\d+')
+  if [[ "$pinned_series" == "$current_series" ]]; then
+    echo "Booted into $current_kernel_version but pinned to $PINNED_KERNEL_VERSION (same $pinned_series series). Skipping module install to avoid rebooting into a broken kernel."
+    exit 0
+  fi
+fi
+
 current_kernel_package="linux-modules-extra-$current_kernel_version"
 
 # Flag to track if a reboot is needed


### PR DESCRIPTION
Several Ubuntu kernels in the 6.8.0-x-generic series have a serious bug [1] where the kernel randomly drops UDP packets. This wreaks havoc in K8s. Cilium especially goes into `CrashLoopBackOff` which in turn kills other pods on the node as they lose networking.

Kernel `6.8.0-106-generic` is a known-good version with a fix for this issue, so this commit adds a workaround to the ansible scripts so that if the latest installed kernel is in the 6.8.0-x-generic series, we pin it to the known-good version and update GRUB accordingly.

Once there is a new kernel series like 6.8.1+ this change becomes no-op so it'll be harmless.

This also fixes a double reboot bug in the `upgrade-apt` playbook (see `Install linux-modules-extra for all installed kernels`) where `apt full-upgrade` installed a new kernel, the node reboots, then the `@reboot` cron from `extra-kernel-modules.sh` detects that `linux-modules-extra` for the new kernel isn't installed, so it installs it and reboots it again. This means that every `ccr upgrade-node` call reboots twice, causing lots of pod crashes. This fixes the problem by pre-installing `linux-modules-extra` for all installed kernels before the reboot, so the cron becomes no-op.

[1] https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2141531