### PR TITLE
Fix Jinja2 integer vs string comparison in replica_count logic

### DIFF
--- a/ansible/cilium-setup.yaml
+++ b/ansible/cilium-setup.yaml
@@ -1,6 +1,8 @@
 - name: Install Cilium on Kubernetes Cluster
   hosts: controlplane[0]
   gather_facts: false
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
   tags:
     - cilium_basic_install
   vars:
@@ -12,7 +14,7 @@
 
     - name: Determine non-API/ETCD server count
       set_fact:
-        replica_count: "{{ 1 if non_api_etcd_server_count <= \"1\" else 2 }}"
+        replica_count: "{{ 1 if non_api_etcd_server_count <= 1 else 2 }}"
 
     - name: Generate cilium.yaml configuration file
       become: yes

--- a/ansible/kubelet-csr-approver.yaml
+++ b/ansible/kubelet-csr-approver.yaml
@@ -2,6 +2,9 @@
 - name: Apply kubelet-serving-cert-approver manifest
   hosts: controlplane[0]
   gather_facts: false
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+    K8S_AUTH_KUBECONFIG: /etc/kubernetes/admin.conf
   vars:
     cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
   tasks:
@@ -12,7 +15,7 @@
 
     - name: Determine if needing HA based on non-API/ETCD server count
       set_fact:
-        kubelet_csr_approver_replica_count: "{{ 1 if non_api_etcd_server_count <= \"1\" else 2 }}"
+        kubelet_csr_approver_replica_count: "{{ 1 if non_api_etcd_server_count <= 1 else 2 }}"
 
     - name: Download the kubelet-serving-cert-approver manifest
       ansible.builtin.get_url:

--- a/ansible/local-storageclasses-setup.yaml
+++ b/ansible/local-storageclasses-setup.yaml
@@ -1,6 +1,9 @@
 - name: Deploy Local StorageClasses
   hosts: controlplane[0]
   gather_facts: false
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+    K8S_AUTH_KUBECONFIG: /etc/kubernetes/admin.conf
   vars:
     cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
     default_storage_class_name: "local-path"

--- a/ansible/metallb-setup.yaml
+++ b/ansible/metallb-setup.yaml
@@ -1,6 +1,8 @@
 - name: Install MetalLB on Kubernetes Cluster
   hosts: controlplane[0]
   gather_facts: false
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
   tags:
     - metallb_basic_install
   vars:

--- a/ansible/metrics-server-setup.yaml
+++ b/ansible/metrics-server-setup.yaml
@@ -2,6 +2,8 @@
 - name: Apply metrics-server manifest
   hosts: controlplane[0]
   gather_facts: false
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
   vars:
     cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
   tasks:
@@ -12,7 +14,7 @@
 
     - name: Determine if needing HA based on non-API/ETCD server count
       set_fact:
-        metrics_server_replica_count: "{{ 1 if non_api_etcd_server_count <= \"1\" else 2 }}"
+        metrics_server_replica_count: "{{ 1 if non_api_etcd_server_count <= 1 else 2 }}"
 
     - name: Add Metrics-Server Helm repository
       ansible.builtin.shell:

--- a/scripts/upgrade_addons.sh
+++ b/scripts/upgrade_addons.sh
@@ -26,6 +26,7 @@ echo -e "${GREEN}Upgrading essential apps from cluster: $CLUSTER_NAME.${ENDCOLOR
 playbooks=(
   "generate-hosts-txt.yaml"
   "trust-hosts.yaml"
+  "move-kubeconfig-remote.yaml"
   "cilium-setup.yaml"
   "kubelet-csr-approver.yaml"
   "local-storageclasses-setup.yaml"


### PR DESCRIPTION
Newer ansible-core versions enforce strict typing and reject <= comparisons between _AnsibleTaggedInt and str. Changed "1" to 1 in cilium-setup, kubelet-csr-approver, and metrics-server-setup playbooks.