### PR TITLE
Add Cilium Local Redirect Policy toggle

### DIFF
--- a/ansible/helpers/cilium_config.yaml.j2
+++ b/ansible/helpers/cilium_config.yaml.j2
@@ -3,7 +3,7 @@ cluster:
   name: {{ cluster_name }}
 operator:
   replicas: {{ replica_count }}
-rolloutCiliumPods: true
+rollOutCiliumPods: true
 ipv4:
   enabled: true
 ipv6:
@@ -24,3 +24,7 @@ cni:
 k8sServiceHost: {{ vip }}
 k8sServicePort: 6443
 kubeProxyReplacement: true
+{% if cilium_local_redirect_policy | default(false) | bool %}
+localRedirectPolicies:
+  enabled: true
+{% endif %}

--- a/clustercreator.sh
+++ b/clustercreator.sh
@@ -105,6 +105,7 @@ run_playbooks() {
     -e cni_plugins_version="$CNI_PLUGINS_VERSION"
     -e etcd_version="$ETCD_VERSION"
     -e cilium_version="$CILIUM_VERSION"
+    -e cilium_local_redirect_policy="${CILIUM_LOCAL_REDIRECT_POLICY:-false}"
     -e metallb_version="$METALLB_VERSION"
     -e local_path_provisioner_version="$LOCAL_PATH_PROVISIONER_VERSION"
     -e metrics_server_version="$METRICS_SERVER_VERSION"

--- a/scripts/k8s.env
+++ b/scripts/k8s.env
@@ -37,6 +37,13 @@ LOCAL_PATH_PROVISIONER_VERSION=0.0.31
 METRICS_SERVER_VERSION=3.13.0
 METALLB_VERSION=0.15.2
 
+# Enable Cilium Local Redirect Policy support (installs the
+# CiliumLocalRedirectPolicy CRD and the feature flag). The capability is
+# dormant until you create LRP resources, so turning it on does not affect
+# traffic by itself. Required for use cases like a node-local DNS cache.
+# Leave false if unused.
+CILIUM_LOCAL_REDIRECT_POLICY=false
+
 # ----------------NVIDIA Drivers (optional)----------------
 # To find versions on Ubuntu:
 #   apt search nvidia-driver | grep -E '^nvidia-driver-[0-9]+-server' | cut -d '/' -f 1


### PR DESCRIPTION
Add CILIUM_LOCAL_REDIRECT_POLICY (default false) to optionally enable Cilium's Local Redirect Policy. When true, the Cilium chart installs the CiliumLocalRedirectPolicy CRD, which is required for e.g. NodeLocal DNS caching.

The default is false to avoid creating the CRD for those who don't need it, but even when the flag is enabled it doesn't affect any traffic unless CiliumLocalRedirectPolicy resources are created.