### PR TITLE
Make kubelet's imageMaximumGCAge configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
   - [Advanced Configurations](#advanced-configurations)
     - [Dynamic Configurations](#dynamic-configurations)
     - [Custom Worker Types](#custom-worker-types)
+    - [Image Garbage Collection](#image-garbage-collection)
   - [Troubleshooting](#troubleshooting)
     - [Installation Errors](#installation-errors)
   - [Final Product](#final-product)
@@ -419,6 +420,23 @@ Custom worker classes would be done to meet specific workload requirements like:
 - **Backup Workers**:
 
     - **Configuration**: Reduced CPU and memory, expanded disks, taints for backup storage.
+
+### Image Garbage Collection
+
+By default the kubelet only garbage-collects container images once disk usage crosses `imageGCHighThresholdPercent` (85%). On clusters that pull frequently-updated images, superseded image versions can accumulate for a long time before that threshold is reached, and pile up unevenly across nodes.
+
+Set `image_maximum_gc_age` on a cluster in `clusters.tf` to have the kubelet also reclaim any image left unused for longer than the given duration, regardless of disk usage:
+
+```tf
+    "beta" = {
+      cluster_name         = "beta"
+      ...
+      image_maximum_gc_age = "168h" # reclaim images unused for over 7 days
+      ...
+    }
+```
+
+> **Note**: the kubelet tracks each image's unused time in memory, so the timer resets when the kubelet restarts.
 
 ---
 

--- a/ansible/helpers/kubeadm_cp_config.yaml.j2
+++ b/ansible/helpers/kubeadm_cp_config.yaml.j2
@@ -40,3 +40,9 @@ etcd:
     certFile: /etc/kubernetes/pki/apiserver-etcd-client.crt
     keyFile: /etc/kubernetes/pki/apiserver-etcd-client.key
 {% endif %}
+{% if cluster_config.image_maximum_gc_age | default('') %}
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+imageMaximumGCAge: {{ cluster_config.image_maximum_gc_age }}
+{% endif %}

--- a/ansible/upgrade-k8s-cluster.yaml
+++ b/ansible/upgrade-k8s-cluster.yaml
@@ -6,6 +6,9 @@
   become: true
   any_errors_fatal: true
 
+  vars:
+    cluster_config: "{{ lookup('file', 'tmp/{{ cluster_name }}/cluster_config.json') | from_json }}"
+
   tasks:
     - name: Create directory for apt keyrings
       ansible.builtin.file:
@@ -66,6 +69,35 @@
       ansible.builtin.fail:
         msg: "User chose not to continue."
       when: "user_confirmation.user_input | lower != 'yes'"
+
+    - name: Reconcile kubelet imageMaximumGCAge in kubelet-config ConfigMap
+      when: cluster_config.image_maximum_gc_age | default('') | length > 0
+      delegate_to: localhost
+      become: false
+      block:
+        - name: Read current imageMaximumGCAge from kubelet-config ConfigMap
+          ansible.builtin.shell: >
+            kubectl get configmap kubelet-config -n kube-system
+            -o jsonpath='{.data.kubelet}' | yq -r '.imageMaximumGCAge // ""'
+          register: current_gc_age
+          changed_when: false
+
+        - name: Patch kubelet-config with desired imageMaximumGCAge
+          when: current_gc_age.stdout | trim != cluster_config.image_maximum_gc_age
+          ansible.builtin.shell: |
+            # Get current KubeletConfiguration YAML, set imageMaximumGCAge, output as YAML
+            PATCHED=$(kubectl get configmap kubelet-config -n kube-system \
+              -o jsonpath='{.data.kubelet}' | yq -y '.imageMaximumGCAge = "{{ cluster_config.image_maximum_gc_age }}"')
+
+            # Update the ConfigMap
+            kubectl get configmap kubelet-config -n kube-system -o json | \
+              jq --arg config "$PATCHED" '.data.kubelet = $config' | \
+              kubectl replace -f -
+          register: gc_age_patch_result
+
+        - name: Show kubelet-config reconcile result
+          ansible.builtin.debug:
+            msg: "{{ gc_age_patch_result.stdout | default('kubelet-config already at imageMaximumGCAge: ' ~ cluster_config.image_maximum_gc_age) }}"
 
     - name: Kubeadm Upgrade Apply
       ansible.builtin.shell:

--- a/terraform/clusters.tf
+++ b/terraform/clusters.tf
@@ -8,6 +8,7 @@ variable "clusters" {
     kubeconfig_file_name     : string                                                     # Required. Name of the local kubeconfig file to be created. Assumed this will be in $HOME/.kube/
     start_on_proxmox_boot    : optional(bool, true)                                       # Optional. Whether or not to start the cluster's vms on proxmox boot
     max_pods_per_node        : optional(number, 512)                                      # Optional. Max pods per node. This should be a function of the quantity of IPs in you pod_cidr and number of nodes.
+    image_maximum_gc_age     : optional(string, "")                                       # Optional. kubelet imageMaximumGCAge (e.g. "168h"). Reclaims images unused for longer than this. Empty leaves the kubeadm/kubelet default (age-based GC disabled).
     reboot_after_update      : optional(bool, false)                                      # Optional. Whether or not to reboot the nodes during terraform apply.
     use_pve_ha               : optional(bool, false)                                      # Optional. Whether to setup PVE High Availability for the VMs. Not currently supported on PVE 9 - https://github.com/bpg/terraform-provider-proxmox/issues/2097
     ssh                      : object({


### PR DESCRIPTION
This lets us configure imageMaximumGCAge in the ConfigMap for kubelet, which is propagated by the upgrade-k8s playbook. It's a no-op if the value is unchanged.

By default kubelet only clears images when the disk is too full, so this is useful for evicting images that churn versions quickly.

---
For me, this was `renovate` which publishes dozens of tags per week :)