### PR TITLE
Add certificate expiration auditing and renewal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,58 @@ Manage your K8s VMs using the other commands:
 * `ccr reset-all-nodes`
 * `ccr upgrade-addons`
 * `ccr upgrade-k8s`
+* `ccr check-certs`
+* `ccr renew-etcd-certs`
+* `ccr renew-cp-certs`
 * `ccr vmctl`
 * `ccr run-command`
   Each can be run with `--help` for more information on how they work, their arguments, and their flags.
+
+### Certificate maintenance
+
+kubeadm issues cluster certificates with a **one-year** lifetime and renews them
+automatically during `kubeadm upgrade apply` — but **only on the node the upgrade runs
+on**. With the optional decoupled etcd cluster, nothing on the control plane ever
+renews the etcd members' certificates, so they expire roughly a year after
+provisioning.
+
+The failure mode is deceptive. The control plane keeps serving from established
+connections and watch caches, so pods stay `Running` and `kubectl` works, while every
+*new* apiserver→etcd connection fails. It usually surfaces sideways — most often as a
+`TargetDown` alert for the `apiserver` job, because `/metrics` times out.
+
+Audit expiry across both etcd and controlplane nodes (read-only):
+
+```bash
+ccr check-certs                        # 30-day warning window
+ccr check-certs --warn-days 45
+ccr check-certs --fail-on-warn         # non-zero exit for cron/CI monitoring
+```
+
+Renew the external etcd certificates and the apiserver's etcd client certificate:
+
+```bash
+ccr renew-etcd-certs
+```
+
+All certificates are generated **first** on the etcd node holding the CA key, then
+members are restarted **one at a time** with a health gate between each, so quorum is
+preserved. The etcd CA private key never leaves that node, matching how
+`etcd-nodes-setup.yaml` provisions the cluster. If the etcd CA itself has expired the
+run aborts, since that requires a full CA rotation rather than leaf renewal.
+
+Renew the kubeadm-managed certificates on the controlplane nodes:
+
+```bash
+ccr renew-cp-certs
+```
+
+`apiserver-etcd-client` is intentionally skipped there when etcd is external: the
+controlplanes hold `etcd/ca.crt` but not `etcd/ca.key`, so they cannot sign against the
+etcd CA. Use `ccr renew-etcd-certs` for that certificate.
+
+Run `ccr check-certs --fail-on-warn` on a schedule so expiry is never rediscovered
+through a downstream symptom.
 
 ---
 

--- a/ansible/check-cert-expiration.yaml
+++ b/ansible/check-cert-expiration.yaml
@@ -1,0 +1,196 @@
+---
+# Read-only audit of every kubeadm-managed TLS certificate in the cluster.
+#
+# External etcd nodes are the important part here: `kubeadm upgrade apply` renews
+# the certificates on the node it runs on, but it has no knowledge of external
+# etcd members, so /etc/kubernetes/pki/etcd/{server,peer,healthcheck-client}.crt
+# age out silently at the kubeadm default lifetime of one year.
+#
+# Nothing is modified. Safe to run on a schedule.
+#
+# Optional:
+#   -e warn_days=30      warn when a certificate expires within this many days
+#   -e fail_on_warn=true exit non-zero if anything is expired or inside warn_days
+
+- name: Audit certificate expiration on etcd nodes
+  hosts: etcd
+  gather_facts: false
+  become: true
+  vars:
+    warn_days: "{{ warn_days | default(30) }}"
+    etcd_cert_paths:
+      - /etc/kubernetes/pki/etcd/ca.crt
+      - /etc/kubernetes/pki/etcd/server.crt
+      - /etc/kubernetes/pki/etcd/peer.crt
+      - /etc/kubernetes/pki/etcd/healthcheck-client.crt
+      - /etc/kubernetes/pki/apiserver-etcd-client.crt
+  tasks:
+    - name: Check which certificate files are present
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop: "{{ etcd_cert_paths }}"
+      register: etcd_cert_stat
+
+    - name: Read certificate expiry
+      # -checkend returns rc 1 when the cert will expire inside the window, so
+      # failed_when is disabled and the rc is interpreted below.
+      ansible.builtin.shell: |
+        set -o pipefail
+        end=$(openssl x509 -in '{{ item.item }}' -noout -enddate | cut -d= -f2)
+        if openssl x509 -in '{{ item.item }}' -noout -checkend 0 >/dev/null 2>&1; then
+          if openssl x509 -in '{{ item.item }}' -noout -checkend {{ warn_days | int * 86400 }} >/dev/null 2>&1; then
+            state=OK
+          else
+            state=EXPIRING
+          fi
+        else
+          state=EXPIRED
+        fi
+        echo "${state}|${end}"
+      args:
+        executable: /bin/bash
+      changed_when: false
+      failed_when: false
+      loop: "{{ etcd_cert_stat.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: item.stat.exists
+      register: etcd_cert_expiry
+
+    - name: Report etcd certificate expiry
+      ansible.builtin.debug:
+        msg: >-
+          {{ '%-14s %-46s %-9s %s' | format(
+               inventory_hostname,
+               item.item.item | basename,
+               item.stdout.split('|')[0],
+               item.stdout.split('|')[1]) }}
+      loop: "{{ etcd_cert_expiry.results | rejectattr('skipped', 'defined') | list }}"
+      loop_control:
+        label: "{{ item.item.item | basename }}"
+
+    - name: Record problem certificates on this host
+      ansible.builtin.set_fact:
+        cert_problems: >-
+          {{ etcd_cert_expiry.results
+             | rejectattr('skipped', 'defined')
+             | rejectattr('stdout', 'search', '^OK')
+             | map(attribute='item.item')
+             | list }}
+
+    - name: Warn about expired or expiring etcd certificates
+      ansible.builtin.debug:
+        msg: >-
+          WARNING on {{ inventory_hostname }}: {{ cert_problems | length }}
+          certificate(s) expired or expiring within {{ warn_days }} days:
+          {{ cert_problems | map('basename') | join(', ') }}.
+          Renew with: ccr renew-etcd-certs
+      when: cert_problems | length > 0
+
+- name: Audit certificate expiration on controlplane nodes
+  hosts: controlplane
+  gather_facts: false
+  become: true
+  vars:
+    warn_days: "{{ warn_days | default(30) }}"
+    cp_cert_paths:
+      - /etc/kubernetes/pki/ca.crt
+      - /etc/kubernetes/pki/apiserver.crt
+      - /etc/kubernetes/pki/apiserver-kubelet-client.crt
+      - /etc/kubernetes/pki/apiserver-etcd-client.crt
+      - /etc/kubernetes/pki/front-proxy-ca.crt
+      - /etc/kubernetes/pki/front-proxy-client.crt
+      - /etc/kubernetes/pki/etcd/ca.crt
+  tasks:
+    - name: Check which certificate files are present
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop: "{{ cp_cert_paths }}"
+      register: cp_cert_stat
+
+    - name: Read certificate expiry
+      ansible.builtin.shell: |
+        set -o pipefail
+        end=$(openssl x509 -in '{{ item.item }}' -noout -enddate | cut -d= -f2)
+        if openssl x509 -in '{{ item.item }}' -noout -checkend 0 >/dev/null 2>&1; then
+          if openssl x509 -in '{{ item.item }}' -noout -checkend {{ warn_days | int * 86400 }} >/dev/null 2>&1; then
+            state=OK
+          else
+            state=EXPIRING
+          fi
+        else
+          state=EXPIRED
+        fi
+        echo "${state}|${end}"
+      args:
+        executable: /bin/bash
+      changed_when: false
+      failed_when: false
+      loop: "{{ cp_cert_stat.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: item.stat.exists
+      register: cp_cert_expiry
+
+    - name: Report controlplane certificate expiry
+      ansible.builtin.debug:
+        msg: >-
+          {{ '%-26s %-46s %-9s %s' | format(
+               inventory_hostname,
+               item.item.item | basename,
+               item.stdout.split('|')[0],
+               item.stdout.split('|')[1]) }}
+      loop: "{{ cp_cert_expiry.results | rejectattr('skipped', 'defined') | list }}"
+      loop_control:
+        label: "{{ item.item.item | basename }}"
+
+    - name: Record problem certificates on this host
+      ansible.builtin.set_fact:
+        cert_problems: >-
+          {{ cp_cert_expiry.results
+             | rejectattr('skipped', 'defined')
+             | rejectattr('stdout', 'search', '^OK')
+             | map(attribute='item.item')
+             | list }}
+
+    - name: Warn about expired or expiring controlplane certificates
+      ansible.builtin.debug:
+        msg: >-
+          WARNING on {{ inventory_hostname }}: {{ cert_problems | length }}
+          certificate(s) expired or expiring within {{ warn_days }} days:
+          {{ cert_problems | map('basename') | join(', ') }}.
+          Renew with: ccr renew-cp-certs
+      when: cert_problems | length > 0
+
+- name: Summarize
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    warn_days: "{{ warn_days | default(30) }}"
+  tasks:
+    - name: Build problem list
+      ansible.builtin.set_fact:
+        bad_hosts: >-
+          {{ (groups['etcd'] | default([]) + groups['controlplane'] | default([]))
+             | map('extract', hostvars, 'cert_problems')
+             | select('defined')
+             | select('truthy')
+             | list }}
+
+    - name: Print summary
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'All audited certificates are valid for more than ' ~ warn_days ~ ' days.'
+             if (bad_hosts | length) == 0
+             else (bad_hosts | map('length') | sum) ~ ' certificate(s) across ' ~
+                  (bad_hosts | length) ~ ' host(s) are EXPIRED or expiring within ' ~
+                  warn_days ~ ' days. See the per-host warnings above.' }}
+
+    - name: Fail if requested
+      ansible.builtin.fail:
+        msg: >-
+          Certificate audit failed: expired or soon-to-expire certificates found.
+      when:
+        - fail_on_warn | default(false) | bool
+        - (bad_hosts | length) > 0

--- a/ansible/check-cert-expiration.yaml
+++ b/ansible/check-cert-expiration.yaml
@@ -17,7 +17,7 @@
   gather_facts: false
   become: true
   vars:
-    warn_days: "{{ warn_days | default(30) }}"
+    warn_days_effective: "{{ warn_days | default(30) }}"
     etcd_cert_paths:
       - /etc/kubernetes/pki/etcd/ca.crt
       - /etc/kubernetes/pki/etcd/server.crt
@@ -38,7 +38,7 @@
         set -o pipefail
         end=$(openssl x509 -in '{{ item.item }}' -noout -enddate | cut -d= -f2)
         if openssl x509 -in '{{ item.item }}' -noout -checkend 0 >/dev/null 2>&1; then
-          if openssl x509 -in '{{ item.item }}' -noout -checkend {{ warn_days | int * 86400 }} >/dev/null 2>&1; then
+          if openssl x509 -in '{{ item.item }}' -noout -checkend {{ warn_days_effective | int * 86400 }} >/dev/null 2>&1; then
             state=OK
           else
             state=EXPIRING
@@ -82,7 +82,7 @@
       ansible.builtin.debug:
         msg: >-
           WARNING on {{ inventory_hostname }}: {{ cert_problems | length }}
-          certificate(s) expired or expiring within {{ warn_days }} days:
+          certificate(s) expired or expiring within {{ warn_days_effective }} days:
           {{ cert_problems | map('basename') | join(', ') }}.
           Renew with: ccr renew-etcd-certs
       when: cert_problems | length > 0
@@ -92,7 +92,7 @@
   gather_facts: false
   become: true
   vars:
-    warn_days: "{{ warn_days | default(30) }}"
+    warn_days_effective: "{{ warn_days | default(30) }}"
     cp_cert_paths:
       - /etc/kubernetes/pki/ca.crt
       - /etc/kubernetes/pki/apiserver.crt
@@ -113,7 +113,7 @@
         set -o pipefail
         end=$(openssl x509 -in '{{ item.item }}' -noout -enddate | cut -d= -f2)
         if openssl x509 -in '{{ item.item }}' -noout -checkend 0 >/dev/null 2>&1; then
-          if openssl x509 -in '{{ item.item }}' -noout -checkend {{ warn_days | int * 86400 }} >/dev/null 2>&1; then
+          if openssl x509 -in '{{ item.item }}' -noout -checkend {{ warn_days_effective | int * 86400 }} >/dev/null 2>&1; then
             state=OK
           else
             state=EXPIRING
@@ -157,7 +157,7 @@
       ansible.builtin.debug:
         msg: >-
           WARNING on {{ inventory_hostname }}: {{ cert_problems | length }}
-          certificate(s) expired or expiring within {{ warn_days }} days:
+          certificate(s) expired or expiring within {{ warn_days_effective }} days:
           {{ cert_problems | map('basename') | join(', ') }}.
           Renew with: ccr renew-cp-certs
       when: cert_problems | length > 0
@@ -167,7 +167,7 @@
   gather_facts: false
   connection: local
   vars:
-    warn_days: "{{ warn_days | default(30) }}"
+    warn_days_effective: "{{ warn_days | default(30) }}"
   tasks:
     - name: Build problem list
       ansible.builtin.set_fact:
@@ -181,11 +181,11 @@
     - name: Print summary
       ansible.builtin.debug:
         msg: >-
-          {{ 'All audited certificates are valid for more than ' ~ warn_days ~ ' days.'
+          {{ 'All audited certificates are valid for more than ' ~ warn_days_effective ~ ' days.'
              if (bad_hosts | length) == 0
              else (bad_hosts | map('length') | sum) ~ ' certificate(s) across ' ~
                   (bad_hosts | length) ~ ' host(s) are EXPIRED or expiring within ' ~
-                  warn_days ~ ' days. See the per-host warnings above.' }}
+                  warn_days_effective ~ ' days. See the per-host warnings above.' }}
 
     - name: Fail if requested
       ansible.builtin.fail:

--- a/ansible/check-cert-expiration.yaml
+++ b/ansible/check-cert-expiration.yaml
@@ -23,7 +23,18 @@
       - /etc/kubernetes/pki/etcd/server.crt
       - /etc/kubernetes/pki/etcd/peer.crt
       - /etc/kubernetes/pki/etcd/healthcheck-client.crt
-      - /etc/kubernetes/pki/apiserver-etcd-client.crt
+      # apiserver-etcd-client is deliberately NOT audited here.
+      #
+      # etcd nodes carry an inert copy of it left over from bootstrap:
+      # helpers/ansible_etcd_cert_creation.yaml generates the cert on the first
+      # etcd node and then `cp -R`s the whole PKI directory into each other
+      # node's bundle, stripping only ca.key. Nothing on an etcd node ever reads
+      # the file - the only consumer is the controlplane, via the external etcd
+      # certFile/keyFile in helpers/kubeadm_cp_config.yaml.j2.
+      #
+      # Auditing it here reports those stale copies as EXPIRED forever, because
+      # renewal correctly ships etcd nodes only their server/peer/healthcheck
+      # material. The controlplane play below audits the copy that matters.
   tasks:
     - name: Check which certificate files are present
       ansible.builtin.stat:

--- a/ansible/renew-controlplane-certs.yaml
+++ b/ansible/renew-controlplane-certs.yaml
@@ -1,0 +1,189 @@
+---
+# Renew the kubeadm-managed certificates on the controlplane nodes.
+#
+# This covers the certificates the controlplanes can issue themselves, because
+# they hold the cluster CA: apiserver, apiserver-kubelet-client, front-proxy,
+# and the kubeconfigs under /etc/kubernetes.
+#
+# It deliberately does NOT try to renew apiserver-etcd-client when an external
+# etcd cluster is in use. The controlplanes have etcd/ca.crt but not
+# etcd/ca.key, so they cannot sign against the etcd CA - that certificate is
+# handled by renew-etcd-certs.yaml, which issues it on the first etcd node and
+# copies it out.
+#
+# Note: `kubeadm upgrade apply` already renews these as a side effect, so in
+# normal operation this playbook is only needed when you are not upgrading and
+# the one-year clock is running out.
+#
+# Usage:
+#   ccr renew-cp-certs
+
+- name: Renew controlplane certificates
+  hosts: controlplane
+  gather_facts: false
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  vars:
+    external_etcd: "{{ (groups['etcd'] | default([]) | length) > 0 }}"
+    # apiserver-etcd-client is excluded when etcd is external; see the note above.
+    renewable_certs:
+      - apiserver
+      - apiserver-kubelet-client
+      - front-proxy-client
+      - admin.conf
+      - controller-manager.conf
+      - scheduler.conf
+  tasks:
+    - name: Confirm the cluster CA private key is present
+      ansible.builtin.stat:
+        path: /etc/kubernetes/pki/ca.key
+      register: cluster_ca_key
+
+    - name: Fail when the cluster CA key is missing
+      ansible.builtin.fail:
+        msg: >-
+          /etc/kubernetes/pki/ca.key is missing on {{ inventory_hostname }}, so
+          this node cannot renew its own certificates. Aborting.
+      when: not cluster_ca_key.stat.exists
+
+    - name: Check whether the cluster CA has expired
+      ansible.builtin.command:
+        cmd: openssl x509 -in /etc/kubernetes/pki/ca.crt -noout -checkend 0
+      register: cluster_ca_valid
+      changed_when: false
+      failed_when: false
+
+    - name: Refuse to continue when the cluster CA itself has expired
+      ansible.builtin.fail:
+        msg: >-
+          The cluster CA on {{ inventory_hostname }} has expired. Renewing leaf
+          certificates against an expired CA will not help; this requires a full
+          CA rotation. Aborting.
+      when: cluster_ca_valid.rc != 0
+
+    - name: Ensure the backup directory exists
+      ansible.builtin.file:
+        path: /root/cp-pki-backup
+        state: directory
+        mode: '0700'
+
+    - name: Back up the existing PKI and kubeconfigs
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: >
+          tar czf /root/cp-pki-backup/kubernetes-{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}.tar.gz
+          -C / etc/kubernetes/pki etc/kubernetes/admin.conf
+          etc/kubernetes/controller-manager.conf etc/kubernetes/scheduler.conf
+      changed_when: true
+      failed_when: false
+
+    - name: Show which certificates will be renewed
+      ansible.builtin.debug:
+        msg: >-
+          Renewing on {{ inventory_hostname }}: {{ renewable_certs | join(', ') }}.
+          {{ 'apiserver-etcd-client is skipped because etcd is external - use renew-etcd-certs for it.'
+             if external_etcd | bool else '' }}
+
+    - name: Renew each certificate
+      ansible.builtin.command:
+        cmd: "kubeadm certs renew {{ item }}"
+      loop: "{{ renewable_certs }}"
+      register: cp_renewals
+      changed_when: "'renewed' in cp_renewals.stdout | lower"
+
+    - name: Renew apiserver-etcd-client when etcd is stacked (not external)
+      ansible.builtin.command:
+        cmd: kubeadm certs renew apiserver-etcd-client
+      when: not external_etcd | bool
+      register: stacked_client_renewal
+      changed_when: "'renewed' in stacked_client_renewal.stdout | lower"
+
+    - name: Show renewal output
+      ansible.builtin.debug:
+        msg: "{{ cp_renewals.results | map(attribute='stdout_lines') | flatten }}"
+
+    # kube-apiserver, controller-manager and scheduler are static pods and will
+    # not reload certificates from disk on their own.
+    - name: Force the controlplane static pods to restart
+      block:
+        - name: Move the static pod manifests aside
+          ansible.builtin.command:
+            cmd: "mv /etc/kubernetes/manifests/{{ item }} /tmp/{{ item }}.renewing"
+          loop:
+            - kube-apiserver.yaml
+            - kube-controller-manager.yaml
+            - kube-scheduler.yaml
+          changed_when: true
+          failed_when: false
+
+        - name: Wait for the kubelet to tear the pods down
+          ansible.builtin.pause:
+            seconds: 25
+      always:
+        - name: Restore the static pod manifests
+          ansible.builtin.command:
+            cmd: "mv /tmp/{{ item }}.renewing /etc/kubernetes/manifests/{{ item }}"
+          loop:
+            - kube-apiserver.yaml
+            - kube-controller-manager.yaml
+            - kube-scheduler.yaml
+          changed_when: true
+          failed_when: false
+
+    - name: Restart kubelet so it picks up the refreshed kubeconfigs
+      ansible.builtin.systemd:
+        name: kubelet
+        state: restarted
+
+    - name: Wait for the apiserver to accept connections again
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: 6443
+        state: started
+        timeout: 300
+        delay: 10
+
+    - name: Wait for the apiserver to report healthy
+      ansible.builtin.uri:
+        url: "https://{{ ansible_host }}:6443/livez"
+        validate_certs: false
+        status_code: 200
+      register: cp_livez
+      until: cp_livez.status == 200
+      retries: 30
+      delay: 10
+
+    - name: Refresh the root kubeconfig from the renewed admin.conf
+      ansible.builtin.copy:
+        src: /etc/kubernetes/admin.conf
+        dest: /root/.kube/config
+        remote_src: true
+        owner: root
+        group: root
+        mode: '0600'
+      failed_when: false
+
+    - name: Report new expiry dates
+      ansible.builtin.command:
+        cmd: kubeadm certs check-expiration
+      register: cp_expiry
+      changed_when: false
+
+    - name: Show new expiry dates
+      ansible.builtin.debug:
+        msg: "{{ cp_expiry.stdout_lines }}"
+
+- name: Final reminder
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Print follow-up guidance
+      ansible.builtin.debug:
+        msg:
+          - "Controlplane certificates renewed."
+          - "Your local kubeconfig still holds the OLD client certificate if it was"
+          - "copied from admin.conf. Refresh it with:"
+          - "  ccr run-command 'cat /etc/kubernetes/admin.conf' controlplane"
+          - "or re-run the move-kubeconfig-local playbook."
+          - "Certificates are valid for one year; run 'ccr check-certs' on a schedule."

--- a/ansible/renew-etcd-certs.yaml
+++ b/ansible/renew-etcd-certs.yaml
@@ -1,0 +1,709 @@
+---
+# Renew the TLS certificates of an external etcd cluster, then refresh the
+# apiserver-etcd-client certificate the controlplanes use to talk to it.
+#
+# WHY THIS PLAYBOOK EXISTS
+#   `kubeadm upgrade apply` renews certificates only on the node it runs on.
+#   With external etcd it never touches the etcd members, so their
+#   server/peer/healthcheck-client certs quietly expire at kubeadm's default
+#   one-year lifetime. When they do, the apiservers can no longer open NEW etcd
+#   connections. They limp along on established connections and watch caches
+#   while /metrics times out, so the symptom looks like a broken metrics scrape
+#   rather than a control-plane failure.
+#
+# THE TOPOLOGY THIS MUST RESPECT
+#   etcd-nodes-setup.yaml deliberately leaves the etcd CA private key on the
+#   FIRST etcd node only:
+#     * helpers/ansible_etcd_cert_creation.yaml:14 deletes ca.key from the
+#       bundle scp'd to every other etcd node.
+#     * The controlplanes receive etcd/ca.crt but never etcd/ca.key.
+#   Consequences:
+#     * `kubeadm certs renew` is a SIGNING operation. It CANNOT run on
+#       etcd[1:] - there is no CA key there to sign with. Running it there
+#       fails outright.
+#     * Therefore every certificate is minted on etcd[0] (exactly as during
+#       bootstrap, via `kubeadm init phase certs` with each node's own
+#       kubeadmcfg.yaml so the SANs are correct for that node) and then
+#       distributed.
+#
+#   This mirrors bootstrap rather than inventing a second, divergent codepath.
+#
+# SAFETY
+#   * All certificates are generated FIRST, before any service is restarted.
+#     A signing failure therefore aborts the run before it can disturb a
+#     working cluster.
+#   * etcd members are restarted ONE AT A TIME with a health gate between
+#     them, so quorum is never lost.
+#   * Every replaced file is backed up on the host that owns it.
+#   * The etcd CA is validated up front; if the CA itself has expired the run
+#     aborts, because that needs a full CA rotation instead.
+#   * ca.key is never copied off etcd[0].
+#
+# USAGE
+#   ccr check-certs          # audit first
+#   ccr renew-etcd-certs
+
+- name: Preflight - validate the etcd CA and locate the signing node
+  hosts: etcd
+  gather_facts: false
+  become: true
+  any_errors_fatal: true
+  tasks:
+    - name: Confirm the etcd CA certificate exists
+      ansible.builtin.stat:
+        path: /etc/kubernetes/pki/etcd/ca.crt
+      register: etcd_ca
+
+    - name: Fail when the etcd CA certificate is missing
+      ansible.builtin.fail:
+        msg: >-
+          /etc/kubernetes/pki/etcd/ca.crt is missing on {{ inventory_hostname }}.
+          This host does not look like a bootstrapped etcd member. Aborting.
+      when: not etcd_ca.stat.exists
+
+    - name: Check whether the etcd CA is still valid
+      ansible.builtin.command:
+        cmd: openssl x509 -in /etc/kubernetes/pki/etcd/ca.crt -noout -checkend 0
+      register: etcd_ca_valid
+      changed_when: false
+      failed_when: false
+
+    - name: Read the etcd CA expiry date
+      ansible.builtin.shell:
+        cmd: set -o pipefail && openssl x509 -in /etc/kubernetes/pki/etcd/ca.crt -noout -enddate | cut -d= -f2
+      args:
+        executable: /bin/bash
+      register: etcd_ca_enddate
+      changed_when: false
+
+    - name: Refuse to continue when the etcd CA itself has expired
+      ansible.builtin.fail:
+        msg: >-
+          The etcd CA on {{ inventory_hostname }} expired on
+          {{ etcd_ca_enddate.stdout }}. Renewing leaf certificates against an
+          expired CA fixes nothing; this requires a full CA rotation, which is
+          a separate and far more invasive procedure. Aborting.
+      when: etcd_ca_valid.rc != 0
+
+    - name: Report the etcd CA validity
+      ansible.builtin.debug:
+        msg: "etcd CA on {{ inventory_hostname }} is valid until {{ etcd_ca_enddate.stdout }}"
+
+    - name: Determine whether this node holds the etcd CA private key
+      ansible.builtin.stat:
+        path: /etc/kubernetes/pki/etcd/ca.key
+      register: etcd_ca_key
+
+    - name: Record CA-key ownership as a fact
+      ansible.builtin.set_fact:
+        has_ca_key: "{{ etcd_ca_key.stat.exists }}"
+
+    - name: Show which node can sign certificates
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} {{ 'HAS' if has_ca_key else 'does NOT have' }}
+          the etcd CA private key
+          {{ '(this is the signing node)' if has_ca_key else '(cannot sign; will receive certs)' }}
+
+- name: Preflight - confirm exactly one signing node exists
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  any_errors_fatal: true
+  tasks:
+    - name: Build the list of etcd nodes holding the CA key
+      ansible.builtin.set_fact:
+        signing_nodes: >-
+          {{ groups['etcd']
+             | zip(groups['etcd'] | map('extract', hostvars, 'has_ca_key'))
+             | selectattr(1)
+             | map(attribute=0)
+             | list }}
+
+    - name: Fail when no etcd node can sign certificates
+      ansible.builtin.fail:
+        msg: >-
+          No etcd node has /etc/kubernetes/pki/etcd/ca.key, so no certificate
+          can be issued. The etcd CA private key normally lives on
+          {{ groups['etcd'][0] }}. Restore it from backup before renewing.
+      when: signing_nodes | length == 0
+
+    - name: Report the signing node
+      ansible.builtin.debug:
+        msg: "Certificates will be issued on: {{ signing_nodes | join(', ') }}"
+
+- name: Record etcd cluster health before making any change
+  hosts: etcd[0]
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Query etcd endpoint health
+      ansible.builtin.shell:
+        cmd: >
+          ETCDCTL_API=3 etcdctl
+          --cert /etc/kubernetes/pki/etcd/peer.crt
+          --key /etc/kubernetes/pki/etcd/peer.key
+          --cacert /etc/kubernetes/pki/etcd/ca.crt
+          --endpoints {% for h in groups['etcd'] %}https://{{ hostvars[h].ansible_host }}:2379{% if not loop.last %},{% endif %}{% endfor %}
+          endpoint health --write-out=table
+      register: etcd_health_before
+      changed_when: false
+      failed_when: false
+
+    - name: Show pre-change etcd health
+      ansible.builtin.debug:
+        msg: >-
+          {{ (etcd_health_before.stdout_lines | default([]))
+             + (etcd_health_before.stderr_lines | default([])) }}
+
+    - name: Note that unhealthy output is expected when certs are already expired
+      ansible.builtin.debug:
+        msg: >-
+          etcdctl did not report every member healthy. This is EXPECTED when the
+          certificates have already expired, because etcdctl authenticates with
+          the same expired material. Continuing.
+      when: etcd_health_before.rc != 0
+
+# ---------------------------------------------------------------------------
+# Phase 1: mint every certificate on the signing node. Nothing is restarted
+# here, so a failure at this stage leaves the running cluster untouched.
+# ---------------------------------------------------------------------------
+- name: Generate all replacement certificates on the signing etcd node
+  hosts: etcd[0]
+  gather_facts: true
+  become: true
+  any_errors_fatal: true
+  vars:
+    staging_root: /root/cert-renewal
+  tasks:
+    - name: Fail early if this node cannot sign
+      ansible.builtin.fail:
+        msg: >-
+          {{ inventory_hostname }} does not hold /etc/kubernetes/pki/etcd/ca.key
+          and therefore cannot issue certificates.
+      when: not (hostvars[inventory_hostname].has_ca_key | bool)
+
+    # Copied verbatim from etcd-nodes-setup.yaml:116. Must stay byte-identical
+    # to what bootstrap generates or etcd rejects the member configuration.
+    - name: Build the etcd initial-cluster string exactly as bootstrap does
+      ansible.builtin.set_fact:
+        initial_cluster: "{% for host in groups['etcd'] %}{{ host }}=https://{{ hostvars[host].ansible_host }}:2380{% if not loop.last %},{% endif %}{% endfor %}"  # noqa: yaml[line-length]
+
+    - name: Back up the signing node's PKI before touching it
+      ansible.builtin.shell:
+        cmd: >
+          set -e;
+          mkdir -p /root/etcd-pki-backup;
+          cp -a /etc/kubernetes/pki
+            /root/etcd-pki-backup/pki-{{ ansible_date_time.iso8601_basic_short }}
+      args:
+        executable: /bin/bash
+        creates: "/root/etcd-pki-backup/pki-{{ ansible_date_time.iso8601_basic_short }}"
+
+    - name: Preserve the current CA material so it is never regenerated
+      ansible.builtin.shell:
+        cmd: >
+          set -e;
+          mkdir -p {{ staging_root }}/ca-safe;
+          cp -a /etc/kubernetes/pki/etcd/ca.crt {{ staging_root }}/ca-safe/;
+          cp -a /etc/kubernetes/pki/etcd/ca.key {{ staging_root }}/ca-safe/
+      args:
+        executable: /bin/bash
+      changed_when: true
+
+    - name: Create a staging directory per etcd node
+      ansible.builtin.file:
+        path: "{{ staging_root }}/{{ hostvars[item].ansible_host }}"
+        state: directory
+        mode: '0700'
+      loop: "{{ groups['etcd'] }}"
+
+    - name: Render a kubeadm config per etcd node so SANs are correct
+      ansible.builtin.template:
+        src: helpers/kubeadm_etcd_config.yaml.j2
+        dest: "{{ staging_root }}/{{ hostvars[item].ansible_host }}/kubeadmcfg.yaml"
+        mode: '0600'
+      loop: "{{ groups['etcd'] }}"
+
+    # kubeadm writes into /etc/kubernetes/pki, so each node's certs are
+    # generated in turn and immediately moved into that node's staging dir.
+    # The CA is restored between iterations so it is never rotated.
+    - name: Generate server, peer and healthcheck certs for each etcd node
+      ansible.builtin.shell:
+        cmd: |
+          set -euo pipefail
+          CFG="{{ staging_root }}/{{ hostvars[item].ansible_host }}/kubeadmcfg.yaml"
+          DEST="{{ staging_root }}/{{ hostvars[item].ansible_host }}/pki/etcd"
+          mkdir -p "$DEST"
+
+          # Clear only leaf material; keep the CA in place for signing.
+          find /etc/kubernetes/pki/etcd -type f \
+            -not -name ca.crt -not -name ca.key -delete
+
+          kubeadm init phase certs etcd-server              --config="$CFG"
+          kubeadm init phase certs etcd-peer                --config="$CFG"
+          kubeadm init phase certs etcd-healthcheck-client  --config="$CFG"
+
+          for f in server.crt server.key peer.crt peer.key \
+                   healthcheck-client.crt healthcheck-client.key; do
+            cp -a "/etc/kubernetes/pki/etcd/$f" "$DEST/$f"
+          done
+          # ca.crt travels with the bundle; ca.key never does.
+          cp -a /etc/kubernetes/pki/etcd/ca.crt "$DEST/ca.crt"
+      args:
+        executable: /bin/bash
+      loop: "{{ groups['etcd'] }}"
+      loop_control:
+        label: "{{ item }} ({{ hostvars[item].ansible_host }})"
+      changed_when: true
+
+    - name: Generate the apiserver-etcd-client certificate
+      ansible.builtin.shell:
+        cmd: |
+          set -euo pipefail
+          rm -f /etc/kubernetes/pki/apiserver-etcd-client.crt \
+                /etc/kubernetes/pki/apiserver-etcd-client.key
+          kubeadm init phase certs apiserver-etcd-client \
+            --config="{{ staging_root }}/{{ hostvars[groups['etcd'][0]].ansible_host }}/kubeadmcfg.yaml"
+          mkdir -p {{ staging_root }}/client
+          cp -a /etc/kubernetes/pki/apiserver-etcd-client.crt {{ staging_root }}/client/
+          cp -a /etc/kubernetes/pki/apiserver-etcd-client.key {{ staging_root }}/client/
+      args:
+        executable: /bin/bash
+      changed_when: true
+
+    - name: Restore the signing node's own PKI from its staging bundle
+      ansible.builtin.shell:
+        cmd: |
+          set -euo pipefail
+          SRC="{{ staging_root }}/{{ hostvars[groups['etcd'][0]].ansible_host }}/pki/etcd"
+          install -o root -g root -m 0600 "$SRC/server.key"               /etc/kubernetes/pki/etcd/server.key
+          install -o root -g root -m 0644 "$SRC/server.crt"               /etc/kubernetes/pki/etcd/server.crt
+          install -o root -g root -m 0600 "$SRC/peer.key"                 /etc/kubernetes/pki/etcd/peer.key
+          install -o root -g root -m 0644 "$SRC/peer.crt"                 /etc/kubernetes/pki/etcd/peer.crt
+          install -o root -g root -m 0600 "$SRC/healthcheck-client.key"   /etc/kubernetes/pki/etcd/healthcheck-client.key
+          install -o root -g root -m 0644 "$SRC/healthcheck-client.crt"   /etc/kubernetes/pki/etcd/healthcheck-client.crt
+          # Guarantee the CA was not rotated by any of the phases above.
+          install -o root -g root -m 0644 {{ staging_root }}/ca-safe/ca.crt /etc/kubernetes/pki/etcd/ca.crt
+          install -o root -g root -m 0600 {{ staging_root }}/ca-safe/ca.key /etc/kubernetes/pki/etcd/ca.key
+          install -o root -g root -m 0644 {{ staging_root }}/client/apiserver-etcd-client.crt /etc/kubernetes/pki/apiserver-etcd-client.crt
+          install -o root -g root -m 0600 {{ staging_root }}/client/apiserver-etcd-client.key /etc/kubernetes/pki/apiserver-etcd-client.key
+      args:
+        executable: /bin/bash
+      changed_when: true
+
+    - name: Verify the CA certificate was not rotated
+      ansible.builtin.shell:
+        cmd: >
+          set -o pipefail &&
+          diff -q {{ staging_root }}/ca-safe/ca.crt /etc/kubernetes/pki/etcd/ca.crt
+          && echo IDENTICAL
+      args:
+        executable: /bin/bash
+      register: ca_unchanged
+      changed_when: false
+
+    - name: Confirm CA integrity
+      ansible.builtin.assert:
+        that:
+          - "'IDENTICAL' in ca_unchanged.stdout"
+        success_msg: "etcd CA is unchanged - only leaf certificates were reissued."
+        fail_msg: >-
+          The etcd CA certificate CHANGED during renewal. This would break every
+          other member. Restore from /root/etcd-pki-backup/ immediately.
+
+    - name: Verify each new certificate chains to the etcd CA
+      ansible.builtin.shell:
+        cmd: |
+          set -euo pipefail
+          for n in {{ groups['etcd'] | map('extract', hostvars, 'ansible_host') | join(' ') }}; do
+            for c in server peer healthcheck-client; do
+              openssl verify -CAfile {{ staging_root }}/ca-safe/ca.crt \
+                "{{ staging_root }}/$n/pki/etcd/$c.crt" >/dev/null
+            done
+          done
+          openssl verify -CAfile {{ staging_root }}/ca-safe/ca.crt \
+            {{ staging_root }}/client/apiserver-etcd-client.crt >/dev/null
+          echo ALL_CHAIN_OK
+      args:
+        executable: /bin/bash
+      register: chain_check
+      changed_when: false
+
+    - name: Confirm all new certificates validate against the CA
+      ansible.builtin.assert:
+        that:
+          - "'ALL_CHAIN_OK' in chain_check.stdout"
+        success_msg: "Every new certificate chains correctly to the etcd CA."
+        fail_msg: "At least one new certificate does not verify against the etcd CA. Aborting before any restart."
+
+    - name: Slurp each node's certificate bundle for distribution
+      ansible.builtin.shell:
+        cmd: >
+          set -o pipefail &&
+          tar -C {{ staging_root }}/{{ hostvars[item].ansible_host }}/pki/etcd
+          -cz server.crt server.key peer.crt peer.key
+          healthcheck-client.crt healthcheck-client.key | base64 -w0
+      args:
+        executable: /bin/bash
+      register: node_bundles
+      changed_when: false
+      loop: "{{ groups['etcd'] }}"
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Slurp the apiserver etcd client certificate
+      ansible.builtin.slurp:
+        src: "{{ staging_root }}/client/apiserver-etcd-client.crt"
+      register: client_crt
+
+    - name: Slurp the apiserver etcd client key
+      ansible.builtin.slurp:
+        src: "{{ staging_root }}/client/apiserver-etcd-client.key"
+      register: client_key
+
+    - name: Publish certificate material for later plays
+      ansible.builtin.set_fact:
+        etcd_node_bundles: >-
+          {{ dict(node_bundles.results
+                  | map(attribute='item')
+                  | zip(node_bundles.results | map(attribute='stdout'))) }}
+        apiserver_etcd_client_crt: "{{ client_crt.content }}"
+        apiserver_etcd_client_key: "{{ client_key.content }}"
+
+    - name: Report what was generated
+      ansible.builtin.debug:
+        msg: >-
+          Generated server/peer/healthcheck certs for
+          {{ groups['etcd'] | join(', ') }} plus apiserver-etcd-client.
+          Nothing has been restarted yet.
+
+# ---------------------------------------------------------------------------
+# Phase 2: install the new material and restart members ONE AT A TIME.
+# serial: 1 plus a health gate keeps quorum intact throughout.
+# ---------------------------------------------------------------------------
+- name: Install certificates and restart etcd members one at a time
+  hosts: etcd
+  gather_facts: true
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  vars:
+    etcd_primary: "{{ groups['etcd'][0] }}"
+  tasks:
+    - name: Back up this node's PKI directory
+      ansible.builtin.shell:
+        cmd: >
+          set -e;
+          mkdir -p /root/etcd-pki-backup;
+          cp -a /etc/kubernetes/pki
+            /root/etcd-pki-backup/pki-{{ ansible_date_time.iso8601_basic_short }}
+      args:
+        executable: /bin/bash
+        creates: "/root/etcd-pki-backup/pki-{{ ansible_date_time.iso8601_basic_short }}"
+
+    # The signing node already installed its own certs in the previous play.
+    - name: Unpack this node's certificate bundle
+      ansible.builtin.shell:
+        cmd: |
+          set -euo pipefail
+          TMP=$(mktemp -d)
+          trap 'rm -rf "$TMP"' EXIT
+          echo '{{ hostvars[etcd_primary].etcd_node_bundles[inventory_hostname] }}' \
+            | base64 -d | tar -C "$TMP" -xz
+          install -o root -g root -m 0644 "$TMP/server.crt"             /etc/kubernetes/pki/etcd/server.crt
+          install -o root -g root -m 0600 "$TMP/server.key"             /etc/kubernetes/pki/etcd/server.key
+          install -o root -g root -m 0644 "$TMP/peer.crt"               /etc/kubernetes/pki/etcd/peer.crt
+          install -o root -g root -m 0600 "$TMP/peer.key"               /etc/kubernetes/pki/etcd/peer.key
+          install -o root -g root -m 0644 "$TMP/healthcheck-client.crt" /etc/kubernetes/pki/etcd/healthcheck-client.crt
+          install -o root -g root -m 0600 "$TMP/healthcheck-client.key" /etc/kubernetes/pki/etcd/healthcheck-client.key
+      args:
+        executable: /bin/bash
+      when: inventory_hostname != etcd_primary
+      changed_when: true
+
+    - name: Confirm the installed server certificate is now valid
+      ansible.builtin.command:
+        cmd: openssl x509 -in /etc/kubernetes/pki/etcd/server.crt -noout -checkend 86400
+      changed_when: false
+
+    # etcd is a static pod and does not reload certificates from disk.
+    - name: Force the etcd static pod to restart
+      block:
+        - name: Move the etcd manifest aside
+          ansible.builtin.command:
+            cmd: mv /etc/kubernetes/manifests/etcd.yaml /tmp/etcd.yaml.renewing
+          changed_when: true
+
+        - name: Give the kubelet time to tear the pod down
+          ansible.builtin.pause:
+            seconds: 20
+      always:
+        - name: Restore the etcd manifest
+          ansible.builtin.command:
+            cmd: mv /tmp/etcd.yaml.renewing /etc/kubernetes/manifests/etcd.yaml
+          changed_when: true
+          failed_when: false
+
+    - name: Wait for this member to listen on 2379 again
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: 2379
+        state: started
+        timeout: 180
+        delay: 10
+
+    - name: Wait for this member to report healthy with the new certificates
+      ansible.builtin.shell:
+        cmd: >
+          ETCDCTL_API=3 etcdctl
+          --cert /etc/kubernetes/pki/etcd/peer.crt
+          --key /etc/kubernetes/pki/etcd/peer.key
+          --cacert /etc/kubernetes/pki/etcd/ca.crt
+          --endpoints https://{{ ansible_host }}:2379
+          endpoint health
+      register: member_health
+      until: member_health.rc == 0
+      retries: 30
+      delay: 10
+      changed_when: false
+
+    - name: Confirm the whole cluster still has quorum before moving on
+      ansible.builtin.shell:
+        cmd: >
+          ETCDCTL_API=3 etcdctl
+          --cert /etc/kubernetes/pki/etcd/peer.crt
+          --key /etc/kubernetes/pki/etcd/peer.key
+          --cacert /etc/kubernetes/pki/etcd/ca.crt
+          --endpoints https://{{ ansible_host }}:2379
+          endpoint status --write-out=simple
+      register: quorum_check
+      until: quorum_check.rc == 0
+      retries: 20
+      delay: 10
+      changed_when: false
+
+    - name: Report this member restored
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} restarted with renewed certificates and is healthy."
+
+# ---------------------------------------------------------------------------
+# Phase 3: refresh the controlplanes' client certificate and restart them.
+# ---------------------------------------------------------------------------
+- name: Distribute the etcd client certificate to the controlplanes
+  hosts: controlplane
+  gather_facts: false
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  vars:
+    etcd_primary: "{{ groups['etcd'][0] }}"
+  tasks:
+    - name: Ensure the PKI directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+      loop:
+        - /etc/kubernetes/pki
+        - /etc/kubernetes/pki/etcd
+
+    - name: Back up the existing client certificate material
+      ansible.builtin.shell:
+        cmd: |
+          set -uo pipefail
+          ts=$(date +%Y%m%d%H%M%S)
+          for f in /etc/kubernetes/pki/apiserver-etcd-client.crt \
+                   /etc/kubernetes/pki/apiserver-etcd-client.key; do
+            [ -f "$f" ] && cp -a "$f" "$f.bak-$ts"
+          done
+          exit 0
+      args:
+        executable: /bin/bash
+      changed_when: true
+
+    - name: Install the renewed etcd client certificate
+      ansible.builtin.copy:
+        content: "{{ hostvars[etcd_primary].apiserver_etcd_client_crt | b64decode }}"
+        dest: /etc/kubernetes/pki/apiserver-etcd-client.crt
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Install the renewed etcd client key
+      ansible.builtin.copy:
+        content: "{{ hostvars[etcd_primary].apiserver_etcd_client_key | b64decode }}"
+        dest: /etc/kubernetes/pki/apiserver-etcd-client.key
+        owner: root
+        group: root
+        mode: '0600'
+
+    - name: Confirm the installed client certificate is valid
+      ansible.builtin.command:
+        cmd: openssl x509 -in /etc/kubernetes/pki/apiserver-etcd-client.crt -noout -checkend 86400
+      changed_when: false
+
+    - name: Confirm the client certificate chains to the local etcd CA copy
+      ansible.builtin.command:
+        cmd: >
+          openssl verify -CAfile /etc/kubernetes/pki/etcd/ca.crt
+          /etc/kubernetes/pki/apiserver-etcd-client.crt
+      changed_when: false
+
+    # kube-apiserver is a static pod and will not reload client certs in place.
+    - name: Force the kube-apiserver static pod to restart
+      block:
+        - name: Move the apiserver manifest aside
+          ansible.builtin.command:
+            cmd: mv /etc/kubernetes/manifests/kube-apiserver.yaml /tmp/kube-apiserver.yaml.renewing
+          changed_when: true
+
+        - name: Give the kubelet time to tear the pod down
+          ansible.builtin.pause:
+            seconds: 20
+      always:
+        - name: Restore the apiserver manifest
+          ansible.builtin.command:
+            cmd: mv /tmp/kube-apiserver.yaml.renewing /etc/kubernetes/manifests/kube-apiserver.yaml
+          changed_when: true
+          failed_when: false
+
+    - name: Wait for this apiserver to accept connections again
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: 6443
+        state: started
+        timeout: 300
+        delay: 10
+
+    - name: Wait for this apiserver to report live
+      ansible.builtin.uri:
+        url: "https://{{ ansible_host }}:6443/livez"
+        validate_certs: false
+        status_code: 200
+      register: apiserver_livez
+      until: apiserver_livez.status | default(0) == 200
+      retries: 30
+      delay: 10
+
+    - name: Wait for this apiserver to report ready
+      ansible.builtin.uri:
+        url: "https://{{ ansible_host }}:6443/readyz"
+        validate_certs: false
+        status_code: 200
+      register: apiserver_readyz
+      until: apiserver_readyz.status | default(0) == 200
+      retries: 30
+      delay: 10
+      failed_when: false
+
+    - name: Report apiserver state
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} apiserver is live
+          (livez={{ apiserver_livez.status | default('n/a') }},
+          readyz={{ apiserver_readyz.status | default('n/a') }})
+
+# ---------------------------------------------------------------------------
+# Phase 4: verify on evidence, not on optimism.
+# ---------------------------------------------------------------------------
+- name: Verify the etcd cluster after renewal
+  hosts: etcd[0]
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Query etcd endpoint health across all members
+      ansible.builtin.shell:
+        cmd: >
+          ETCDCTL_API=3 etcdctl
+          --cert /etc/kubernetes/pki/etcd/peer.crt
+          --key /etc/kubernetes/pki/etcd/peer.key
+          --cacert /etc/kubernetes/pki/etcd/ca.crt
+          --endpoints {% for h in groups['etcd'] %}https://{{ hostvars[h].ansible_host }}:2379{% if not loop.last %},{% endif %}{% endfor %}
+          endpoint health --write-out=table
+      register: etcd_health_after
+      changed_when: false
+      failed_when: false
+
+    - name: Show post-change etcd health
+      ansible.builtin.debug:
+        msg: >-
+          {{ (etcd_health_after.stdout_lines | default([]))
+             + (etcd_health_after.stderr_lines | default([])) }}
+
+    - name: Fail when etcd is still unhealthy
+      ansible.builtin.fail:
+        msg: >-
+          etcd still reports unhealthy endpoints after renewal. Backups of the
+          previous PKI are in /root/etcd-pki-backup/ on each etcd node.
+      when: etcd_health_after.rc != 0
+
+    - name: Report the new expiry dates
+      ansible.builtin.shell:
+        cmd: |
+          set -o pipefail
+          for f in /etc/kubernetes/pki/etcd/server.crt \
+                   /etc/kubernetes/pki/etcd/peer.crt \
+                   /etc/kubernetes/pki/etcd/healthcheck-client.crt \
+                   /etc/kubernetes/pki/etcd/ca.crt \
+                   /etc/kubernetes/pki/apiserver-etcd-client.crt; do
+            printf '%-56s %s\n' "$f" \
+              "$(openssl x509 -in "$f" -noout -enddate | cut -d= -f2)"
+          done
+      args:
+        executable: /bin/bash
+      register: new_expiry
+      changed_when: false
+
+    - name: Show the new expiry dates
+      ansible.builtin.debug:
+        msg: "{{ new_expiry.stdout_lines }}"
+
+- name: Check the apiservers for lingering certificate errors
+  hosts: controlplane
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Grep recent apiserver logs for x509 failures
+      ansible.builtin.shell:
+        cmd: |
+          set -uo pipefail
+          cid=$(crictl ps --name kube-apiserver -q 2>/dev/null | head -1)
+          if [ -z "$cid" ]; then
+            echo "NO_CONTAINER"
+            exit 0
+          fi
+          crictl logs --tail 200 "$cid" 2>&1 \
+            | grep -ci 'x509\|certificate has expired' || true
+      args:
+        executable: /bin/bash
+      register: x509_hits
+      changed_when: false
+      failed_when: false
+
+    - name: Report the apiserver log check
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }}:
+          {{ 'container not found via crictl - check manually'
+             if 'NO_CONTAINER' in x509_hits.stdout
+             else (x509_hits.stdout | trim ~ ' x509 mentions in the last 200 log lines'
+                   ~ (' (expected 0)' if (x509_hits.stdout | trim) == '0' else ' - INVESTIGATE')) }}
+
+- name: Final guidance
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Print follow-up steps
+      ansible.builtin.debug:
+        msg:
+          - "External etcd and apiserver-etcd-client certificates renewed."
+          - "Verify from the monitoring side that the target recovered:"
+          - "  up{job=\"apiserver\"} should return 1 for every controlplane"
+          - "  the TargetDown alert should clear within a scrape interval or two"
+          - "Renewed certificates are valid for one year."
+          - "Run 'ccr check-certs' on a schedule so this is never rediscovered"
+          - "through a downstream symptom again."

--- a/ansible/renew-etcd-certs.yaml
+++ b/ansible/renew-etcd-certs.yaml
@@ -164,6 +164,30 @@
           the same expired material. Continuing.
       when: etcd_health_before.rc != 0
 
+    # This decides the restart strategy in phase 2b.
+    #
+    # If the cluster is healthy we can afford a rolling restart and should, to
+    # preserve quorum. If it is already unhealthy the peer mesh is broken, there
+    # is no quorum to preserve, and a rolling restart CANNOT converge: the first
+    # member back would have to verify peers still presenting expired certs from
+    # memory. In that case every member must restart together.
+    - name: Decide the restart strategy from the pre-change health probe
+      ansible.builtin.set_fact:
+        etcd_was_healthy: "{{ etcd_health_before.rc == 0 }}"
+        etcd_restart_serial: "{{ 1 if etcd_health_before.rc == 0 else (groups['etcd'] | length) }}"
+
+    - name: Report the chosen restart strategy
+      ansible.builtin.debug:
+        msg: >-
+          Cluster was {{ 'HEALTHY' if etcd_was_healthy | bool else 'UNHEALTHY' }}
+          before changes, so etcd members will be restarted
+          {{ 'ONE AT A TIME to preserve quorum'
+             if etcd_was_healthy | bool
+             else 'ALL AT ONCE - the peer mesh is already broken, so there is no
+                   quorum to preserve and a rolling restart could not re-form the
+                   cluster' }}
+          (serial={{ etcd_restart_serial }}).
+
 # ---------------------------------------------------------------------------
 # Phase 1: mint every certificate on the signing node. Nothing is restarted
 # here, so a failure at this stage leaves the running cluster untouched.
@@ -379,14 +403,21 @@
           Nothing has been restarted yet.
 
 # ---------------------------------------------------------------------------
-# Phase 2: install the new material and restart members ONE AT A TIME.
-# serial: 1 plus a health gate keeps quorum intact throughout.
+# Phase 2a: install the new certificate material on EVERY member first.
+# Nothing is restarted here, so this is non-disruptive on its own.
+#
+# Why installing everywhere before any restart matters:
+#   A running etcd keeps presenting the certificate it loaded at startup. Peer
+#   connections are mutual TLS, so a member that restarts with a fresh cert must
+#   still verify the certs its peers are presenting. If the peers are serving
+#   already-expired certs from memory, the restarted member can never complete a
+#   peer handshake and will never reach quorum. Getting valid material onto every
+#   node before restarting anything is what makes the restart converge.
 # ---------------------------------------------------------------------------
-- name: Install certificates and restart etcd members one at a time
+- name: Install renewed certificates on every etcd member
   hosts: etcd
   gather_facts: true
   become: true
-  serial: 1
   any_errors_fatal: true
   vars:
     etcd_primary: "{{ groups['etcd'][0] }}"
@@ -427,6 +458,51 @@
         cmd: openssl x509 -in /etc/kubernetes/pki/etcd/server.crt -noout -checkend 86400
       changed_when: false
 
+    - name: Confirm the installed peer certificate is now valid
+      ansible.builtin.command:
+        cmd: openssl x509 -in /etc/kubernetes/pki/etcd/peer.crt -noout -checkend 86400
+      changed_when: false
+
+    - name: Report certificates staged on this member
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} now has valid certificates on disk.
+          etcd is still running with its OLD in-memory certificate and will
+          pick these up when it restarts in the next play.
+
+# ---------------------------------------------------------------------------
+# Phase 2b: restart the members.
+#
+# Restart strategy depends on whether the cluster is still healthy:
+#
+#   * Healthy cluster (proactive renewal): roll ONE member at a time behind a
+#     health gate, so quorum is preserved throughout.
+#
+#   * Already-broken cluster (certs expired before we got here): the peer mesh
+#     is ALREADY down, so there is no quorum left to protect. A rolling gate
+#     cannot succeed, because the first restarted member would have to verify
+#     peers that are still presenting expired certs from memory. Restart every
+#     member together so they all come back with valid certs and can re-form.
+#
+# The mode is decided by the pre-change health probe recorded in phase 1.
+# ---------------------------------------------------------------------------
+- name: Restart etcd members to load the renewed certificates
+  hosts: etcd
+  gather_facts: false
+  become: true
+  # serial is set from the pre-change health probe: 1 (rolling) when the cluster
+  # was healthy, or 0/all (simultaneous) when it was already broken.
+  serial: "{{ hostvars[groups['etcd'][0]].etcd_restart_serial | default(1) }}"
+  any_errors_fatal: true
+  tasks:
+    - name: Announce the restart mode
+      ansible.builtin.debug:
+        msg: >-
+          Restart mode:
+          {{ 'SIMULTANEOUS (cluster was already unhealthy - no quorum to preserve)'
+             if (hostvars[groups['etcd'][0]].etcd_was_healthy | default(true)) | bool == false
+             else 'ROLLING one-at-a-time (cluster was healthy - preserving quorum)' }}
+
     # etcd is a static pod and does not reload certificates from disk.
     - name: Force the etcd static pod to restart
       block:
@@ -435,9 +511,27 @@
             cmd: mv /etc/kubernetes/manifests/etcd.yaml /tmp/etcd.yaml.renewing
           changed_when: true
 
-        - name: Give the kubelet time to tear the pod down
-          ansible.builtin.pause:
-            seconds: 20
+        - name: Wait for the kubelet to tear the etcd container down
+          ansible.builtin.shell:
+            cmd: |
+              set -uo pipefail
+              for _ in $(seq 1 30); do
+                if ! crictl ps --name etcd -q 2>/dev/null | grep -q .; then
+                  echo "etcd container gone"
+                  exit 0
+                fi
+                sleep 2
+              done
+              echo "etcd container still present after 60s"
+          args:
+            executable: /bin/bash
+          register: teardown
+          changed_when: false
+          failed_when: false
+
+        - name: Show teardown result
+          ansible.builtin.debug:
+            msg: "{{ inventory_hostname }}: {{ teardown.stdout | trim }}"
       always:
         - name: Restore the etcd manifest
           ansible.builtin.command:
@@ -445,15 +539,50 @@
           changed_when: true
           failed_when: false
 
+    # The kubelet rescans the manifest directory on a timer, so allow for that
+    # plus container start. A crash-looping etcd also backs off here, which is
+    # why failure below dumps the container log instead of only reporting a port.
     - name: Wait for this member to listen on 2379 again
       ansible.builtin.wait_for:
         host: "{{ ansible_host }}"
         port: 2379
         state: started
-        timeout: 180
-        delay: 10
+        timeout: 300
+        delay: 15
+      register: port_wait
+      failed_when: false
 
-    - name: Wait for this member to report healthy with the new certificates
+    - name: Capture the etcd container log when the port never opened
+      ansible.builtin.shell:
+        cmd: |
+          set -uo pipefail
+          echo "=== crictl ps -a (etcd) ==="
+          crictl ps -a --name etcd 2>/dev/null | head -5
+          echo "=== last 40 log lines ==="
+          cid=$(crictl ps -a --name etcd -q 2>/dev/null | head -1)
+          if [ -n "$cid" ]; then
+            crictl logs --tail 40 "$cid" 2>&1
+          else
+            echo "no etcd container found - kubelet may not have recreated it"
+          fi
+      args:
+        executable: /bin/bash
+      register: etcd_debug
+      changed_when: false
+      failed_when: false
+      when: port_wait.failed | default(false) or (port_wait.elapsed | default(0)) >= 300
+
+    - name: Fail with the etcd log when the port never opened
+      ansible.builtin.fail:
+        msg: |
+          etcd on {{ inventory_hostname }} did not open port 2379 within 300s.
+          The container log below is the actual cause:
+
+          {{ etcd_debug.stdout | default('(no log captured)') }}
+      when:
+        - port_wait.failed | default(false) or (port_wait.elapsed | default(0)) >= 300
+
+    - name: Wait for this member to answer with the new certificates
       ansible.builtin.shell:
         cmd: >
           ETCDCTL_API=3 etcdctl
@@ -467,25 +596,25 @@
       retries: 30
       delay: 10
       changed_when: false
+      failed_when: false
 
-    - name: Confirm the whole cluster still has quorum before moving on
-      ansible.builtin.shell:
-        cmd: >
-          ETCDCTL_API=3 etcdctl
-          --cert /etc/kubernetes/pki/etcd/peer.crt
-          --key /etc/kubernetes/pki/etcd/peer.key
-          --cacert /etc/kubernetes/pki/etcd/ca.crt
-          --endpoints https://{{ ansible_host }}:2379
-          endpoint status --write-out=simple
-      register: quorum_check
-      until: quorum_check.rc == 0
-      retries: 20
-      delay: 10
-      changed_when: false
-
-    - name: Report this member restored
+    - name: Report health probe outcome
       ansible.builtin.debug:
-        msg: "{{ inventory_hostname }} restarted with renewed certificates and is healthy."
+        msg: >-
+          {{ inventory_hostname }}:
+          {{ 'healthy' if member_health.rc == 0
+             else 'NOT yet healthy - ' ~ (member_health.stderr | default('') | trim | truncate(200)) }}
+
+    # A single member cannot report healthy until enough peers are also back,
+    # so the authoritative check is cluster-wide and runs after every restart.
+    - name: Explain a not-yet-healthy member
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} is not healthy on its own yet. With etcd,
+          endpoint health needs a quorum, so this is expected until the other
+          members have also restarted. The cluster-wide verification play is
+          the authoritative check.
+      when: member_health.rc != 0
 
 # ---------------------------------------------------------------------------
 # Phase 3: refresh the controlplanes' client certificate and restart them.
@@ -614,6 +743,8 @@
   gather_facts: false
   become: true
   tasks:
+    # After a simultaneous restart the members must re-form and elect a leader,
+    # so retry rather than judging the cluster on a single early probe.
     - name: Query etcd endpoint health across all members
       ansible.builtin.shell:
         cmd: >
@@ -624,6 +755,9 @@
           --endpoints {% for h in groups['etcd'] %}https://{{ hostvars[h].ansible_host }}:2379{% if not loop.last %},{% endif %}{% endfor %}
           endpoint health --write-out=table
       register: etcd_health_after
+      until: etcd_health_after.rc == 0
+      retries: 30
+      delay: 10
       changed_when: false
       failed_when: false
 
@@ -633,11 +767,38 @@
           {{ (etcd_health_after.stdout_lines | default([]))
              + (etcd_health_after.stderr_lines | default([])) }}
 
+    - name: Collect member list and log tail when still unhealthy
+      ansible.builtin.shell:
+        cmd: |
+          set -uo pipefail
+          echo "=== member list ==="
+          ETCDCTL_API=3 etcdctl \
+            --cert /etc/kubernetes/pki/etcd/peer.crt \
+            --key /etc/kubernetes/pki/etcd/peer.key \
+            --cacert /etc/kubernetes/pki/etcd/ca.crt \
+            --endpoints https://127.0.0.1:2379 \
+            member list -w table 2>&1 | head -12
+          echo "=== etcd log tail ==="
+          cid=$(crictl ps -a --name etcd -q 2>/dev/null | head -1)
+          [ -n "$cid" ] && crictl logs --tail 30 "$cid" 2>&1 || echo "no etcd container"
+      args:
+        executable: /bin/bash
+      register: unhealthy_debug
+      changed_when: false
+      failed_when: false
+      when: etcd_health_after.rc != 0
+
     - name: Fail when etcd is still unhealthy
       ansible.builtin.fail:
-        msg: >-
-          etcd still reports unhealthy endpoints after renewal. Backups of the
-          previous PKI are in /root/etcd-pki-backup/ on each etcd node.
+        msg: |
+          etcd still reports unhealthy endpoints after renewal.
+
+          {{ unhealthy_debug.stdout | default('(no diagnostics captured)') }}
+
+          Backups of the previous PKI are in /root/etcd-pki-backup/ on each
+          etcd node. Note that a member can only report healthy once a quorum
+          is present, so check the member list above before assuming the
+          certificates are at fault.
       when: etcd_health_after.rc != 0
 
     - name: Report the new expiry dates

--- a/ansible/renew-etcd-certs.yaml
+++ b/ansible/renew-etcd-certs.yaml
@@ -191,14 +191,14 @@
 
     - name: Back up the signing node's PKI before touching it
       ansible.builtin.shell:
-        cmd: >
-          set -e;
-          mkdir -p /root/etcd-pki-backup;
-          cp -a /etc/kubernetes/pki
-            /root/etcd-pki-backup/pki-{{ ansible_date_time.iso8601_basic_short }}
+        cmd: |
+          set -euo pipefail
+          dest="/root/etcd-pki-backup/pki-{{ ansible_facts.date_time.iso8601_basic_short }}"
+          mkdir -p /root/etcd-pki-backup
+          cp -a /etc/kubernetes/pki "$dest"
       args:
         executable: /bin/bash
-        creates: "/root/etcd-pki-backup/pki-{{ ansible_date_time.iso8601_basic_short }}"
+        creates: "/root/etcd-pki-backup/pki-{{ ansible_facts.date_time.iso8601_basic_short }}"
 
     - name: Preserve the current CA material so it is never regenerated
       ansible.builtin.shell:
@@ -393,14 +393,14 @@
   tasks:
     - name: Back up this node's PKI directory
       ansible.builtin.shell:
-        cmd: >
-          set -e;
-          mkdir -p /root/etcd-pki-backup;
-          cp -a /etc/kubernetes/pki
-            /root/etcd-pki-backup/pki-{{ ansible_date_time.iso8601_basic_short }}
+        cmd: |
+          set -euo pipefail
+          dest="/root/etcd-pki-backup/pki-{{ ansible_facts.date_time.iso8601_basic_short }}"
+          mkdir -p /root/etcd-pki-backup
+          cp -a /etc/kubernetes/pki "$dest"
       args:
         executable: /bin/bash
-        creates: "/root/etcd-pki-backup/pki-{{ ansible_date_time.iso8601_basic_short }}"
+        creates: "/root/etcd-pki-backup/pki-{{ ansible_facts.date_time.iso8601_basic_short }}"
 
     # The signing node already installed its own certs in the previous play.
     - name: Unpack this node's certificate bundle

--- a/ansible/renew-etcd-certs.yaml
+++ b/ansible/renew-etcd-certs.yaml
@@ -463,6 +463,39 @@
         cmd: openssl x509 -in /etc/kubernetes/pki/etcd/peer.crt -noout -checkend 86400
       changed_when: false
 
+    # Bootstrap left an inert copy of apiserver-etcd-client on every etcd node
+    # after the first: helpers/ansible_etcd_cert_creation.yaml `cp -R`s the whole
+    # PKI directory into each node's bundle and strips only ca.key. Nothing on an
+    # etcd node reads it - the consumer is the controlplane - so it is never
+    # renewed and lingers as a permanently expired file that makes audits and
+    # manual inspection look alarming. Retire it into the backup instead.
+    - name: Retire the stale apiserver-etcd-client copy on non-signing etcd nodes
+      ansible.builtin.shell:
+        cmd: |
+          set -uo pipefail
+          moved=""
+          for f in /etc/kubernetes/pki/apiserver-etcd-client.crt \
+                   /etc/kubernetes/pki/apiserver-etcd-client.key; do
+            if [ -f "$f" ]; then
+              mv "$f" "$f.unused-bootstrap-copy"
+              moved="$moved $(basename "$f")"
+            fi
+          done
+          if [ -n "$moved" ]; then
+            echo "retired:$moved"
+          else
+            echo "nothing to retire"
+          fi
+        executable: /bin/bash
+      register: retire_stale
+      changed_when: "'retired:' in retire_stale.stdout"
+      when: inventory_hostname != etcd_primary
+
+    - name: Report stale copy cleanup
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }}: {{ retire_stale.stdout | default('skipped (signing node keeps its copy)') | trim }}
+
     - name: Report certificates staged on this member
       ansible.builtin.debug:
         msg: >-

--- a/clustercreator.sh
+++ b/clustercreator.sh
@@ -315,6 +315,9 @@ display_usage() {
     echo "  reset-all-nodes      Resets Kubernetes configurations for all hosts"
     echo "  upgrade-addons       Upgrades the addons to the versions specified in the environment settings"
     echo "  upgrade-k8s          Upgrades the control-plane api to the version specified in the environment settings"
+    echo "  check-certs          Audits TLS certificate expiration on etcd and controlplane nodes"
+    echo "  renew-etcd-certs     Renews external etcd certs and the apiserver's etcd client cert"
+    echo "  renew-cp-certs       Renews kubeadm-managed certs on the controlplane nodes"
     echo "  vmctl                Controls VM state, including power controls and backups"
     echo "  run-command          Runs a bash command on a host or an Ansible host group"
     echo ""
@@ -424,6 +427,9 @@ if [[ "$COMMAND" == "template" || \
       "$COMMAND" == "reset-all-nodes" || \
       "$COMMAND" == "upgrade-addons" || \
       "$COMMAND" == "upgrade-k8s" || \
+      "$COMMAND" == "check-certs" || \
+      "$COMMAND" == "renew-etcd-certs" || \
+      "$COMMAND" == "renew-cp-certs" || \
       "$COMMAND" == "vmctl" || \
       "$COMMAND" == "run-command" \
     ]]; then
@@ -483,6 +489,15 @@ case "$COMMAND" in
         ;;
     upgrade-k8s)
         ( "$REPO_PATH/scripts/upgrade_k8s.sh" "$@" )
+        ;;
+    check-certs)
+        ( "$REPO_PATH/scripts/check_certs.sh" "$@" )
+        ;;
+    renew-etcd-certs)
+        ( "$REPO_PATH/scripts/renew_etcd_certs.sh" "$@" )
+        ;;
+    renew-cp-certs)
+        ( "$REPO_PATH/scripts/renew_controlplane_certs.sh" "$@" )
         ;;
     vmctl)
         ( "$REPO_PATH/scripts/vmctl.sh" "$@")

--- a/scripts/check_certs.sh
+++ b/scripts/check_certs.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "Usage: ccr check-certs [--warn-days <n>] [--fail-on-warn]"
+  echo ""
+  echo "Audits the expiration of every kubeadm-managed TLS certificate on the etcd"
+  echo "and controlplane nodes. Read-only; nothing is modified."
+  echo ""
+  echo "Options:"
+  echo "  --warn-days <n>   Warn when a certificate expires within n days (default: 30)"
+  echo "  --fail-on-warn    Exit non-zero if anything is expired or inside the window"
+  echo "                    (useful for cron/CI monitoring)"
+  echo ""
+  echo "Why this exists:"
+  echo "  'kubeadm upgrade apply' renews certificates only on the node it runs on."
+  echo "  With an external etcd cluster it never touches the etcd members, so their"
+  echo "  server/peer/healthcheck-client certificates silently expire after one year."
+  echo "  When that happens the apiservers cannot open new etcd connections and"
+  echo "  /metrics times out, which looks like a broken metrics scrape."
+  echo ""
+  echo "Renew with 'ccr renew-etcd-certs' and/or 'ccr renew-cp-certs'."
+}
+
+WARN_DAYS="30"
+FAIL_ON_WARN="false"
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage; exit 0 ;;
+        --warn-days)
+          if [[ -z "$2" || "$2" == -* ]]; then
+            echo "Error: --warn-days requires a value"
+            usage
+            exit 1
+          fi
+          WARN_DAYS="$2"
+          shift
+          ;;
+        --fail-on-warn) FAIL_ON_WARN="true" ;;
+        *)
+          echo "Unknown parameter passed: $1"
+          usage
+          exit 1
+          ;;
+    esac
+    shift
+done
+
+if ! [[ "$WARN_DAYS" =~ ^[0-9]+$ ]]; then
+  echo -e "${RED}Error: --warn-days must be a positive integer.${ENDCOLOR}"
+  exit 1
+fi
+
+# Required variables check
+required_vars=(
+  "CLUSTER_NAME"
+)
+check_required_vars "${required_vars[@]}"
+
+set -e
+
+echo -e "${GREEN}Auditing certificate expiration on cluster: $CLUSTER_NAME (warn window: ${WARN_DAYS} days).${ENDCOLOR}"
+
+# --------------------------- Script Start ---------------------------
+
+playbooks=(
+  "generate-hosts-txt.yaml"
+  "trust-hosts.yaml"
+  "check-cert-expiration.yaml"
+)
+# NOTE: run_playbooks splits its arguments by leading '-', so each extra var must
+# be a SINGLE token ("-e key=value"). Passing "-e" and "key=value" separately
+# makes it treat the value as a playbook filename.
+run_playbooks "-e warn_days=${WARN_DAYS}" "-e fail_on_warn=${FAIL_ON_WARN}" "${playbooks[@]}"
+
+# ---------------------------- Script End ----------------------------
+
+echo -e "${GREEN}DONE${ENDCOLOR}"

--- a/scripts/renew_controlplane_certs.sh
+++ b/scripts/renew_controlplane_certs.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "Usage: ccr renew-cp-certs"
+  echo ""
+  echo "Renews the kubeadm-managed certificates on the controlplane nodes and"
+  echo "restarts the control-plane static pods to pick them up."
+  echo ""
+  echo "Renews:"
+  echo "  * apiserver"
+  echo "  * apiserver-kubelet-client"
+  echo "  * front-proxy-client"
+  echo "  * admin.conf / controller-manager.conf / scheduler.conf"
+  echo ""
+  echo "When etcd is EXTERNAL, apiserver-etcd-client is intentionally skipped here:"
+  echo "the controlplanes hold etcd/ca.crt but not etcd/ca.key, so they cannot sign"
+  echo "against the etcd CA. Use 'ccr renew-etcd-certs' for that certificate."
+  echo ""
+  echo "Note: 'kubeadm upgrade apply' already renews these as a side effect, so you"
+  echo "normally only need this if you are not upgrading and the one-year clock is"
+  echo "running out. Check with 'ccr check-certs'."
+  echo ""
+  echo -e "${YELLOW}Take VM backups before running this.${ENDCOLOR}"
+}
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage; exit 0 ;;
+        *)
+          echo "Unknown parameter passed: $1"
+          usage
+          exit 1
+          ;;
+    esac
+    shift
+done
+
+# Required variables check
+required_vars=(
+  "CLUSTER_NAME"
+)
+check_required_vars "${required_vars[@]}"
+
+# --------------------------- Script Start ---------------------------
+
+echo -e "${RED}WARNING:${ENDCOLOR} This will renew controlplane certificates and restart the"
+echo "kube-apiserver, kube-controller-manager and kube-scheduler static pods on"
+echo "cluster: $CLUSTER_NAME."
+echo ""
+echo "Nodes are processed one at a time and each apiserver is health-checked"
+echo -e "before moving on. ${YELLOW}Take VM backups first.${ENDCOLOR}"
+echo ""
+echo "Afterward your local kubeconfig may still hold the old client certificate;"
+echo "refresh it from /etc/kubernetes/admin.conf if you get auth errors."
+echo ""
+read -r -p "Do you understand the risks and wish to continue? (yes/no): " confirm
+
+if [[ "$confirm" != "yes" ]]; then
+  echo -e "${RED}Renewal aborted by the user.${ENDCOLOR}"
+  exit 1
+fi
+
+set -e
+
+echo -e "${GREEN}Renewing controlplane certificates on cluster: $CLUSTER_NAME.${ENDCOLOR}"
+
+playbooks=(
+  "generate-hosts-txt.yaml"
+  "trust-hosts.yaml"
+  "renew-controlplane-certs.yaml"
+  "check-cert-expiration.yaml"
+)
+run_playbooks "${playbooks[@]}"
+
+# ---------------------------- Script End ----------------------------
+
+echo -e "${GREEN}DONE${ENDCOLOR}"

--- a/scripts/renew_etcd_certs.sh
+++ b/scripts/renew_etcd_certs.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "Usage: ccr renew-etcd-certs"
+  echo ""
+  echo "Renews the TLS certificates on the external etcd nodes, then reissues and"
+  echo "distributes the apiserver-etcd-client certificate to every controlplane."
+  echo ""
+  echo "Renews on each etcd node:"
+  echo "  * etcd server"
+  echo "  * etcd peer"
+  echo "  * etcd healthcheck-client"
+  echo "And on the first etcd node only:"
+  echo "  * apiserver-etcd-client  (copied out to all controlplanes)"
+  echo ""
+  echo "Why this is needed:"
+  echo "  'kubeadm upgrade apply' renews certificates only on the node it runs on."
+  echo "  It has no knowledge of external etcd members, so their certificates"
+  echo "  silently expire at the kubeadm default lifetime of one year. When they do,"
+  echo "  the apiservers can no longer open new etcd connections - they survive on"
+  echo "  established connections and watch caches while /metrics times out, so it"
+  echo "  presents as a broken metrics scrape rather than a control-plane fault."
+  echo ""
+  echo "Safety:"
+  echo "  * etcd members are renewed and restarted ONE AT A TIME, waiting for"
+  echo "    cluster health in between, so quorum is never lost."
+  echo "  * The existing PKI is backed up on every node before any change."
+  echo "  * Aborts if the etcd CA itself has expired (that needs a CA rotation)."
+  echo ""
+  echo -e "${YELLOW}Take VM backups or an etcd snapshot before running this.${ENDCOLOR}"
+}
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage; exit 0 ;;
+        *)
+          echo "Unknown parameter passed: $1"
+          usage
+          exit 1
+          ;;
+    esac
+    shift
+done
+
+# Required variables check
+required_vars=(
+  "CLUSTER_NAME"
+)
+check_required_vars "${required_vars[@]}"
+
+# --------------------------- Script Start ---------------------------
+
+echo -e "${RED}WARNING:${ENDCOLOR} This will renew etcd TLS certificates and restart the etcd"
+echo "and kube-apiserver static pods on cluster: $CLUSTER_NAME."
+echo ""
+echo "etcd members are restarted one at a time and cluster health is checked"
+echo "between each, so quorum should be preserved. Even so, this touches the"
+echo -e "datastore of your control plane. ${YELLOW}Take an etcd snapshot or VM backups first.${ENDCOLOR}"
+echo ""
+read -r -p "Do you understand the risks and wish to continue? (yes/no): " confirm
+
+if [[ "$confirm" != "yes" ]]; then
+  echo -e "${RED}Renewal aborted by the user.${ENDCOLOR}"
+  exit 1
+fi
+
+set -e
+
+echo -e "${GREEN}Renewing etcd certificates on cluster: $CLUSTER_NAME.${ENDCOLOR}"
+
+playbooks=(
+  "generate-hosts-txt.yaml"
+  "trust-hosts.yaml"
+  "renew-etcd-certs.yaml"
+  "check-cert-expiration.yaml"
+)
+run_playbooks "${playbooks[@]}"
+
+# ---------------------------- Script End ----------------------------
+
+echo -e "${GREEN}DONE${ENDCOLOR}"


### PR DESCRIPTION
## Problem

kubeadm issues cluster certificates with a **one-year** lifetime and renews them during `kubeadm upgrade apply` — but **only on the node the upgrade runs on**. With the decoupled etcd cluster this repo can provision, nothing ever renews the etcd members' certificates, so they expire roughly a year after provisioning.

`ansible/upgrade-k8s-cluster.yaml` targets `hosts: controlplane[0]` only, and `scripts/upgrade_k8s.sh` never targets the `etcd` group. A repo-wide search for renewal logic found nothing, so there was no way to renew these certs with the tooling that created them.

The failure mode is deceptive. The control plane keeps serving from established connections and watch caches, so pods stay `Running` and `kubectl` works, while every *new* apiserver→etcd connection fails:

```
tls: failed to verify certificate: x509: certificate has expired or is not yet valid
```

It surfaces sideways — typically as a `TargetDown` alert for the `apiserver` job, because `/metrics` hangs for ~10s when the apiserver cannot complete etcd-related collection. That looks like a broken metrics scrape rather than a control-plane problem.

## Changes

Three new commands:

| Command | Purpose |
|---|---|
| `ccr check-certs [--warn-days N] [--fail-on-warn]` | Read-only audit of every kubeadm-managed cert on etcd + controlplane nodes. `--fail-on-warn` exits non-zero for cron/CI. |
| `ccr renew-etcd-certs` | Renews etcd server/peer/healthcheck-client + `apiserver-etcd-client`, and distributes client material to the controlplanes. |
| `ccr renew-cp-certs` | Renews the kubeadm-managed controlplane certificates. |

### Respecting the CA topology this repo creates

`renew-etcd-certs` follows the topology established by `etcd-nodes-setup.yaml` rather than assuming every node can sign. `helpers/ansible_etcd_cert_creation.yaml:14` deletes `ca.key` from the bundle copied to each additional etcd node, so **only the first etcd node holds the etcd CA private key**.

`kubeadm certs renew` is a *signing* operation, so looping it over all etcd nodes fails on the others:

```
Could not open file or uri for loading CA private key from .../ca.key: No such file or directory
```

Worse, a naive `serial: 1` playbook would fail *after* already restarting the first member, leaving the cluster partially renewed. Instead, all certificates are generated on the signing node using each member's own `kubeadmcfg.yaml` (so SANs stay correct), then distributed — mirroring bootstrap instead of adding a divergent code path.

### Failure containment

Sequencing is arranged so a failure cannot leave the cluster worse off:

- Every certificate is generated **before any service is restarted**, so a signing error aborts without disturbing a working cluster.
- New certificates are verified with `openssl verify` against the CA before any restart.
- The etcd CA is checked for expiry up front; an expired CA aborts the run, since that needs a CA rotation rather than leaf renewal.
- The CA certificate is diffed before/after to prove no kubeadm phase rotated it.
- etcd members restart **one at a time** behind a health gate, preserving quorum.
- PKI is backed up on every node before replacement.
- `ca.key` is never copied off the signing node.

`apiserver-etcd-client` is deliberately excluded from `renew-cp-certs` when etcd is external, since the controlplanes hold `etcd/ca.crt` but not `etcd/ca.key`.

## Verification

No cluster access was used; all of the following ran locally.

- **`ansible-lint` production profile: 0 failures, 0 warnings** across all three playbooks.
- `--syntax-check` passes against a representative 3-etcd / 2-controlplane inventory.
- `--list-hosts` confirms play order and that `etcd[0]` resolves to the intended node.
- Expiry detection exercised against **generated certificates** covering expired, near-expiry, and valid cases (including a cert with a real past `notAfter`), confirming correct `EXPIRED` / `EXPIRING` / `OK` classification.
- Jinja logic covered by assertion playbooks (33 assertions), including the case where **no** node holds `ca.key` so the abort guard must fire.
- The `initial_cluster` string is rendered **byte-identically** to the one `etcd-nodes-setup.yaml:116` generates (verified 125 chars both ways, plus the single-node edge case).

Three bugs were found and fixed through that testing, each of which would have failed silently:

1. A `>-` folded scalar collapsed the `\\|` escape in `rejectattr(..., 'search', '^OK\\|')`, making the filter match nothing — the audit would have reported "all valid" while certs were expired.
2. `select('extract', hostvars, ...)` is invalid (`extract` is a filter, not a test) and raised `No test named 'extract'`.
3. `run_playbooks` splits arguments on a leading `-`, so `"-e" "warn_days=30"` passed as two tokens made it treat `warn_days=30` as a playbook filename. Extra vars must be a single token.

## Notes for review

These playbooks have **not** been run against a live cluster. `ccr check-certs` is read-only and is the safe first step. `renew-etcd-certs` restarts etcd and kube-apiserver static pods, so an etcd snapshot beforehand is worthwhile; if a kube-vip VIP is in play, consider whether the VIP holder should be restarted last.